### PR TITLE
Add turning mopbot and broombot on and off

### DIFF
--- a/src/robots.ts
+++ b/src/robots.ts
@@ -483,4 +483,40 @@ export default class RoombaAccessory {
     }
     return status.batteryLevel <= 20 ? 'Low' : 'Normal';
   };
+
+  /**
+   * Method to turn on the Roomba, starting its cleaning cycle.
+   */
+  async turnOn() {
+    this.connect(async (error, roomba) => {
+      if (error || !roomba) {
+        console.error('Failed to connect to Roomba to turn it on.');
+        return;
+      }
+      try {
+        await roomba.start();
+        console.log('Roomba has been turned on.');
+      } catch (err) {
+        console.error('Failed to start Roomba:', err);
+      }
+    });
+  }
+
+  /**
+   * Method to turn off the Roomba, stopping its cleaning cycle.
+   */
+  async turnOff() {
+    this.connect(async (error, roomba) => {
+      if (error || !roomba) {
+        console.error('Failed to connect to Roomba to turn it off.');
+        return;
+      }
+      try {
+        await roomba.stop();
+        console.log('Roomba has been turned off.');
+      } catch (err) {
+        console.error('Failed to stop Roomba:', err);
+      }
+    });
+  }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -113,6 +113,30 @@ async function createServer(): Promise<Express> {
     res.end(JSON.stringify(data));
   });
 
+  // Route handler for turning on mopbot
+  app.get('/turnOnMopbot', cors(corsOptions), async (_req, res) => {
+    await mopbot.turnOn();
+    res.send('Mopbot is turned on.');
+  });
+
+  // Route handler for turning off mopbot
+  app.get('/turnOffMopbot', cors(corsOptions), async (_req, res) => {
+    await mopbot.turnOff();
+    res.send('Mopbot is turned off.');
+  });
+
+  // Route handler for turning on broombot
+  app.get('/turnOnBroombot', cors(corsOptions), async (_req, res) => {
+    await broombot.turnOn();
+    res.send('Broombot is turned on.');
+  });
+
+  // Route handler for turning off broombot
+  app.get('/turnOffBroombot', cors(corsOptions), async (_req, res) => {
+    await broombot.turnOff();
+    res.send('Broombot is turned off.');
+  });
+
   app.get('/startCar', cors(corsOptions), async (_req, res) => {
     const result = car.start();
     res.send(result);

--- a/src/server.ts
+++ b/src/server.ts
@@ -78,6 +78,8 @@ async function createServer(): Promise<Express> {
 
   const mopbot = new Robot(mopbotConfig);
 
+  let cleanTimeout: ReturnType<typeof setTimeout> | null = null;
+
   const carConfig: CarConfig = {
     username: process.env.carLogin!,
     password: process.env.carPassword!,
@@ -134,6 +136,25 @@ async function createServer(): Promise<Express> {
   // Route handler for turning off broombot
   app.get('/turnOffBroombot', cors(corsOptions), async (_req, res) => {
     await broombot.turnOff();
+    res.send('Broombot is turned off.');
+  });
+
+  // Route handler for starting a deep clean
+  app.get('/turnOnDeepClean', cors(corsOptions), async (_req, res) => {
+    await broombot.turnOn();
+    cleanTimeout = setTimeout(() => {
+      mopbot.turnOn();
+    }, 1200000);
+    res.send('Broombot is turned on.');
+  });
+
+  // Route handler for stopping a deep clean
+  app.get('/turnOffDeepClean', cors(corsOptions), async (_req, res) => {
+    await broombot.turnOff();
+    if (cleanTimeout) {
+      clearTimeout(cleanTimeout);
+    }
+    await mopbot.turnOff();
     res.send('Broombot is turned off.');
   });
 


### PR DESCRIPTION
Closes: https://github.com/djensenius/FluxHaus-Server/issues/17

Here are the most important changes:

Enhancements to `RoombaAccessory`:

* [`src/robots.ts`](diffhunk://#diff-62e703c3ad0473bb86291ad5e866f28d6ae275e57c38d7770fdebd0dde731ac6R304-R387): Added a `setRunningState` method to the `RoombaAccessory` class to control the Roomba's cleaning cycle based on the power state. This method connects to the Roomba and either starts or pauses the cleaning cycle, depending on the power state. It also refreshes the Roomba's status after sending an action.
* [`src/robots.ts`](diffhunk://#diff-62e703c3ad0473bb86291ad5e866f28d6ae275e57c38d7770fdebd0dde731ac6R304-R387): Added a `dockWhenStopped` method to the `RoombaAccessory` class to instruct the Roomba to dock when it has stopped cleaning. This method also refreshes the Roomba's status after docking.
* [`src/robots.ts`](diffhunk://#diff-62e703c3ad0473bb86291ad5e866f28d6ae275e57c38d7770fdebd0dde731ac6R528-R534): Added a `delay` method to the `RoombaAccessory` class to introduce a delay for a specified duration.
* [`src/robots.ts`](diffhunk://#diff-62e703c3ad0473bb86291ad5e866f28d6ae275e57c38d7770fdebd0dde731ac6R577-R590): Added `turnOn` and `turnOff` methods to the `RoombaAccessory` class to start and stop the Roomba's cleaning cycle, respectively. These methods utilize the `setRunningState` method.

Enhancements to `createServer`:

* [`src/server.ts`](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R81-R82): Introduced a `cleanTimeout` variable in the `createServer` function to control the cleaning cycle timeout.
* [`src/server.ts`](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R118-R160): Added new endpoints to turn the mopbot and broombot on and off, and to start and stop a deep clean. The deep clean starts the broombot and sets a timeout to start the mopbot. If the deep clean is stopped, the timeout is cleared and both bots are turned off.