### PR TITLE
Add starttime to robots

### DIFF
--- a/src/robots.ts
+++ b/src/robots.ts
@@ -63,6 +63,13 @@ interface Status {
     paused?: boolean
     batteryLevel?: number
     binFull?: boolean
+    timeStarted?: Date
+}
+
+interface RobotStatePlus extends RobotState {
+  lastCommand?: {
+    time: number;
+  }
 }
 
 const EMPTY_STATUS: Status = {
@@ -409,7 +416,7 @@ export default class RoombaAccessory {
     this.cachedStatus = status;
   }
 
-  static parseState(state: RobotState) {
+  static parseState(state: RobotStatePlus) {
     const status: Status = {
       timestamp: Date.now(),
     };
@@ -417,6 +424,12 @@ export default class RoombaAccessory {
     if (state.batPct !== undefined) {
       status.batteryLevel = state.batPct;
     }
+
+    console.log('state', JSON.stringify(state));
+    if (state?.lastCommand?.time !== undefined) {
+      status.timeStarted = new Date(state.lastCommand.time * 1000);
+    }
+
     if (state.bin !== undefined) {
       status.binFull = state.bin.full;
     }


### PR DESCRIPTION
Key changes include:

* [`interface Status {`](diffhunk://#diff-62e703c3ad0473bb86291ad5e866f28d6ae275e57c38d7770fdebd0dde731ac6R66-R72): A `timeStarted` field of type `Date` has been added to the `Status` interface. This field is intended to store the time when the robot started its operation.

* [`interface RobotStatePlus`](diffhunk://#diff-62e703c3ad0473bb86291ad5e866f28d6ae275e57c38d7770fdebd0dde731ac6R66-R72): A new interface `RobotStatePlus` has been introduced, which extends the `RobotState` interface. It includes an optional `lastCommand` field, which is an object containing a `time` field. This new interface allows for the tracking of the last command issued to the robot and the time it was issued.

* [`export default class RoombaAccessory {`](diffhunk://#diff-62e703c3ad0473bb86291ad5e866f28d6ae275e57c38d7770fdebd0dde731ac6L412-R432): The `parseState` method within the `RoombaAccessory` class has been updated to accept `RobotStatePlus` instead of `RobotState`. This change is to accommodate the newly added `lastCommand` field. Additionally, the method now checks if `state.lastCommand.time` is defined, and if so, it sets `status.timeStarted` to a new `Date` object based on `state.lastCommand.time`. This allows the start time of the last command to be tracked.