### PR TITLE
Add i18n support for JSON responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "express": "^4.19.2",
     "express-basic-auth": "^1.2.1",
     "express-rate-limit": "^7.3.1",
-    "nocache": "^4.0.0"
+    "nocache": "^4.0.0",
+    "i18next": "^21.6.14",
+    "i18next-express-middleware": "^1.9.1"
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,0 +1,16 @@
+{
+  "staticStrings": {
+    "notFound": "Not Found",
+    "mopbotOn": "Mopbot is turned on.",
+    "mopbotOff": "Mopbot is turned off.",
+    "broombotOn": "Broombot is turned on.",
+    "broombotOff": "Broombot is turned off.",
+    "deepCleanOn": "Broombot is turned on.",
+    "deepCleanOff": "Broombot is turned off.",
+    "carStart": "Car is started.",
+    "carStop": "Car is stopped.",
+    "carResync": "Resyncing car",
+    "carLock": "Car is locked.",
+    "carUnlock": "Car is unlocked."
+  }
+}

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1,0 +1,16 @@
+{
+  "staticStrings": {
+    "notFound": "No encontrado",
+    "mopbotOn": "Mopbot está encendido.",
+    "mopbotOff": "Mopbot está apagado.",
+    "broombotOn": "Broombot está encendido.",
+    "broombotOff": "Broombot está apagado.",
+    "deepCleanOn": "Broombot está encendido.",
+    "deepCleanOff": "Broombot está apagado.",
+    "carStart": "El coche está encendido.",
+    "carStop": "El coche está apagado.",
+    "carResync": "Resincronizando coche",
+    "carLock": "El coche está bloqueado.",
+    "carUnlock": "El coche está desbloqueado."
+  }
+}


### PR DESCRIPTION
Add i18n support for JSON responses using i18next and i18next-express-middleware.

* **Dependencies**: Add `i18next` and `i18next-express-middleware` to `package.json`.
* **Localization Files**: Add `src/locales/en/translation.json` and `src/locales/es/translation.json` for English and Spanish translations.
* **Server Initialization**: Import and initialize `i18next` and `i18next-express-middleware` in `src/server.ts`. Add middleware for language detection and translation.
* **Route Handlers**: Update JSON responses in `src/server.ts` to use i18next for translating static strings.
* **Language Change Route**: Add a new route in `src/server.ts` to change the language dynamically.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/djensenius/FluxHaus-Server?shareId=a4ab2929-6723-4f36-9268-ecf089b2f9a5).