### PR TITLE
Update workflows for tagging

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -30,7 +30,18 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
 
-      - name: Bump version and push tag
+      - name: Bump version
+        id: version
         run: |
-          npm version ${{ github.event.inputs.version_type }} -m "chore: release %s"
-          git push origin main --follow-tags
+          npm version ${{ github.event.inputs.version_type }} --no-git-tag-version
+          echo "new_version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: release ${{ steps.version.outputs.new_version }}"
+          title: "chore: release ${{ steps.version.outputs.new_version }}"
+          body: "This PR bumps the version to ${{ steps.version.outputs.new_version }}."
+          branch: "release/${{ steps.version.outputs.new_version }}"
+          base: "main"

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -1,0 +1,27 @@
+---
+name: Tag on Merge
+
+"on":
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Create Tag
+        run: |
+          VERSION=${{ github.event.pull_request.head.ref }}
+          VERSION=${VERSION#release/}
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push origin "v$VERSION"


### PR DESCRIPTION
This pull request updates the release workflow to create a release pull request instead of pushing directly to `main`, and introduces a new workflow to automatically tag releases when the release pull request is merged. These changes improve release management by making version bumps more transparent and automating tag creation.

**Release workflow improvements:**

* The manual release workflow now creates a pull request for version bumps instead of pushing changes directly to `main`, making the release process more visible and reviewable. (`.github/workflows/manual-release.yml`)

**Automated tagging:**

* A new workflow (`.github/workflows/tag-on-merge.yml`) automatically creates and pushes a version tag when a release pull request (with a branch name starting with `release/`) is merged into `main`. This ensures consistent tagging for releases.