### PR TITLE
Fix timezone in Docker and await car status on init

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: ghcr.io/djensenius/fluxhaus-server:latest
     # build: .
     network_mode: "host"
+    environment:
+      - TZ=America/Toronto
     volumes:
       - ./cache:/app/cache
       - .env:/app/.env

--- a/src/__tests__/car.test.ts
+++ b/src/__tests__/car.test.ts
@@ -56,10 +56,8 @@ describe('Car', () => {
     jest.useRealTimers();
   });
 
-  it('should fetch status on initialization', async () => {
-    // setStatus is called in constructor, wait for it
-    await Promise.resolve();
-    await Promise.resolve();
+  it('should fetch status when setStatus is called', async () => {
+    await car.setStatus();
 
     expect(mockClient.getState).toHaveBeenCalledWith(`sensor.${entityPrefix}_ev_battery_level`);
     expect(mockClient.getState).toHaveBeenCalledWith(`lock.${entityPrefix}_door_lock`);

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -71,6 +71,7 @@ describe('Server', () => {
     mockCar = {
       status: {},
       odometer: 1000,
+      setStatus: jest.fn().mockResolvedValue(undefined),
       start: jest.fn().mockResolvedValue('Started'),
       stop: jest.fn().mockResolvedValue('Stopped'),
       lock: jest.fn().mockResolvedValue('Locked'),

--- a/src/car.ts
+++ b/src/car.ts
@@ -82,7 +82,6 @@ export default class Car {
     this.odometer = 0;
 
     this.loadCachedStatus();
-    this.setStatus();
     setInterval(() => {
       this.setStatus();
     }, carConfig.pollInterval ?? 1000 * 60 * 5);

--- a/src/server.ts
+++ b/src/server.ts
@@ -89,6 +89,7 @@ export async function createServer(): Promise<Express> {
   };
 
   const car = new Car(carConfig);
+  await car.setStatus();
   const cameraURL = process.env.CAMERA_URL || '';
   const clientId = process.env.mieleClientId || '';
   const secretId = process.env.mieleSecretId || '';


### PR DESCRIPTION
## Changes

- **Add `TZ=America/Toronto` to docker-compose.yml** — The container was running in UTC, so the car's "last updated" timestamp from Kia Connect was displayed with the wrong timezone offset.
- **Move `car.setStatus()` from constructor to server startup with `await`** — Ensures initial car status is fetched before the server starts listening for requests.
- **Update tests** to match the new initialization flow.

## Portainer

After merging: pull the latest image and **recreate** the stack to pick up the new `TZ` environment variable. Also copy the updated `docker-compose.yml` to the host.