### PR TITLE
Use HA's last_changed instead of Kia's broken last_updated_at

### DIFF
--- a/src/car.ts
+++ b/src/car.ts
@@ -154,7 +154,7 @@ export default class Car {
         defrost,
         engine,
         odometerState,
-        lastUpdated,
+        lastUpdatedEntity,
       ] = await Promise.all([
         this.getEntityState(`sensor.${prefix}_ev_battery_level`),
         this.getEntityState(`binary_sensor.${prefix}_ev_battery_charge`),
@@ -172,8 +172,10 @@ export default class Car {
         this.getEntityState(`binary_sensor.${prefix}_defrost`),
         this.getEntityState(`binary_sensor.${prefix}_engine`),
         this.getEntityState(`sensor.${prefix}_odometer`),
-        this.getEntityState(`sensor.${prefix}_last_updated_at`),
+        this.client.getState(`sensor.${prefix}_last_updated_at`),
       ]);
+
+      const lastUpdated = lastUpdatedEntity.last_changed || lastUpdatedEntity.state;
 
       if (!this.isStatusValid(batteryLevel, evRange, totalRange, lastUpdated)) {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
## Problem

The Kia Connect integration's `last_updated_at` sensor returns a timestamp ~5 hours in the future. It appears to double-convert EST→UTC, e.g. reporting `07:34 UTC` when the actual update was at `00:47 UTC`.

This causes the iOS app to show "Updated in 4 hours" instead of the correct relative time.

## Fix

Fetch the full HA state object for `last_updated_at` and use HA's `last_changed` metadata (the actual time HA received the update from Kia) instead of the sensor's broken `state` value.