### PR TITLE
Add CAMERA_ROMPER_URL and CAMERA_GYM_URL camera feeds

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -63,6 +63,8 @@ CAR_ENTITY_PREFIX=kia
 
 # Camera
 CAMERA_URL=
+CAMERA_ROMPER_URL=
+CAMERA_GYM_URL=
 
 # Miele Integration
 mieleClientId=

--- a/src/__tests__/ai-command.test.ts
+++ b/src/__tests__/ai-command.test.ts
@@ -58,6 +58,8 @@ describe('executeTool', () => {
       mieleClient: { washer: { status: 'Idle' }, dryer: { status: 'Running' } } as any,
       dishwasher: { dishwasher: { operationState: 'Run', programProgress: 50 } } as any,
       cameraURL: '',
+      romperURL: '',
+      gymURL: '',
     };
     /* eslint-enable @typescript-eslint/no-explicit-any */
   });
@@ -241,6 +243,8 @@ describe('executeAICommand', () => {
       mieleClient: {} as any,
       dishwasher: {} as any,
       cameraURL: '',
+      romperURL: '',
+      gymURL: '',
     };
     /* eslint-enable @typescript-eslint/no-explicit-any */
   });

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -83,6 +83,8 @@ describe('MCP Server', () => {
         dishwasher: {},
       } as any,
       cameraURL: 'http://camera.local/stream',
+      romperURL: '',
+      gymURL: '',
     };
     /* eslint-enable @typescript-eslint/no-explicit-any */
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -242,6 +242,8 @@ export async function createServer(): Promise<Express> {
   const car = new Car(carConfig);
   await car.setStatus();
   const cameraURL = process.env.CAMERA_URL || '';
+  const romperURL = process.env.CAMERA_ROMPER_URL || '';
+  const gymURL = process.env.CAMERA_GYM_URL || '';
   const mieleClient = new HomeAssistantMiele({
     client: homeAssistantClient,
     pollInterval: 10_000,
@@ -350,6 +352,8 @@ export async function createServer(): Promise<Express> {
     mieleClient,
     dishwasher,
     cameraURL,
+    romperURL,
+    gymURL,
     plex,
     overseerr,
     tautulli,
@@ -447,6 +451,8 @@ export async function createServer(): Promise<Express> {
         carEvStatus: evStatus,
         carOdometer: car.odometer,
         cameraURL,
+        romperURL,
+        gymURL,
         rhizomeSchedule,
         rhizomeData,
         miele,
@@ -459,6 +465,8 @@ export async function createServer(): Promise<Express> {
       data = {
         version,
         cameraURL,
+        romperURL,
+        gymURL,
         rhizomeSchedule,
         rhizomeData,
       };

--- a/src/services.ts
+++ b/src/services.ts
@@ -33,6 +33,8 @@ export interface FluxHausServices {
   mieleClient: HomeAssistantMiele;
   dishwasher: HomeAssistantDishwasher;
   cameraURL: string;
+  romperURL: string;
+  gymURL: string;
   plex?: PlexClient;
   overseerr?: OverseerrClient;
   tautulli?: TautulliClient;
@@ -101,6 +103,8 @@ export async function createServices(): Promise<FluxHausServices> {
     mieleClient,
     dishwasher,
     cameraURL: process.env.CAMERA_URL || '',
+    romperURL: process.env.CAMERA_ROMPER_URL || '',
+    gymURL: process.env.CAMERA_GYM_URL || '',
     plex: new PlexClient({
       url: (process.env.PLEX_URL || '').trim(),
       token: (process.env.PLEX_TOKEN || '').trim(),


### PR DESCRIPTION
## What's new

Adds support for two additional camera feeds to complement the existing Toybox camera.

### Changes
- `CAMERA_ROMPER_URL` and `CAMERA_GYM_URL` read from environment
- `romperURL` and `gymURL` included in both the admin and `rhizome` role API responses
- `FluxHausServices` interface updated with the two new fields
- `.env-example` documents the new variables

### Companion
These fields are consumed by the Rhizome app (see companion PR) which shows a Toybox / Romper / Gym switcher overlay in the video player.