### PR TITLE
Add weather data to GT3 rides

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -233,6 +233,16 @@ export async function initDatabase(): Promise<void> {
       -- Add gear_mode column if missing (existing deployments)
       ALTER TABLE gt3_rides ADD COLUMN IF NOT EXISTS gear_mode INTEGER;
 
+      -- Weather data for rides
+      ALTER TABLE gt3_rides ADD COLUMN IF NOT EXISTS weather_temp DOUBLE PRECISION;
+      ALTER TABLE gt3_rides ADD COLUMN IF NOT EXISTS weather_feels_like DOUBLE PRECISION;
+      ALTER TABLE gt3_rides ADD COLUMN IF NOT EXISTS weather_humidity DOUBLE PRECISION;
+      ALTER TABLE gt3_rides ADD COLUMN IF NOT EXISTS weather_wind_speed DOUBLE PRECISION;
+      ALTER TABLE gt3_rides ADD COLUMN IF NOT EXISTS weather_wind_direction DOUBLE PRECISION;
+      ALTER TABLE gt3_rides ADD COLUMN IF NOT EXISTS weather_condition TEXT;
+      ALTER TABLE gt3_rides ADD COLUMN IF NOT EXISTS weather_uv_index DOUBLE PRECISION;
+      ALTER TABLE gt3_rides ADD COLUMN IF NOT EXISTS weather_pressure DOUBLE PRECISION;
+
       CREATE TABLE IF NOT EXISTS gt3_snapshots (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
         user_sub TEXT NOT NULL,

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -93,11 +93,17 @@ router.post('/ride', async (req, res) => {
     const userSub = req.user?.sub || 'unknown';
     const result = await pool.query(
       `INSERT INTO gt3_rides (user_sub, start_time, end_time, distance, max_speed, avg_speed,
-        battery_used, start_battery, end_battery, gear_mode, gps_track, health_data, metadata)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13) RETURNING id`,
+        battery_used, start_battery, end_battery, gear_mode, gps_track, health_data, metadata,
+        weather_temp, weather_feels_like, weather_humidity, weather_wind_speed,
+        weather_wind_direction, weather_condition, weather_uv_index, weather_pressure)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)
+       RETURNING id`,
       [userSub, r.startTime, r.endTime, r.distance ?? r.totalDistance, r.maxSpeed, r.avgSpeed,
         r.batteryUsed, r.startBattery, r.endBattery, r.primaryGearMode ?? r.gearMode ?? null,
-        r.gpsTrack || null, r.healthData || null, r.metadata || null],
+        r.gpsTrack || null, r.healthData || null, r.metadata || null,
+        r.weather?.temp ?? null, r.weather?.feelsLike ?? null, r.weather?.humidity ?? null,
+        r.weather?.windSpeed ?? null, r.weather?.windDirection ?? null,
+        r.weather?.condition ?? null, r.weather?.uvIndex ?? null, r.weather?.pressure ?? null],
     );
     const rideId = result.rows[0]?.id;
     const rideFields: Record<string, number> = {
@@ -111,6 +117,11 @@ router.post('/ride', async (req, res) => {
     if (r.healthData) {
       rideFields.avg_heart_rate = r.healthData.avgHeartRate ?? 0;
       rideFields.total_calories = r.healthData.totalCalories ?? 0;
+    }
+    if (r.weather) {
+      rideFields.weather_temp = r.weather.temp ?? 0;
+      rideFields.weather_humidity = r.weather.humidity ?? 0;
+      rideFields.weather_wind_speed = r.weather.windSpeed ?? 0;
     }
     writePoint('gt3_ride', rideFields, { scooter: 'GT3Pro', ride_id: rideId || 'unknown' });
     gt3Logger.info({ rideId }, 'Stored ride');
@@ -132,7 +143,10 @@ router.get('/rides', async (req, res) => {
     const offset = (page - 1) * limit;
     const result = await pool.query(
       `SELECT id, start_time, end_time, distance, max_speed, avg_speed,
-        battery_used, start_battery, end_battery, gear_mode, health_data, metadata, created_at
+        battery_used, start_battery, end_battery, gear_mode, health_data, metadata,
+        weather_temp, weather_feels_like, weather_humidity, weather_wind_speed,
+        weather_wind_direction, weather_condition, weather_uv_index, weather_pressure,
+        created_at
        FROM gt3_rides WHERE user_sub = $1
        ORDER BY start_time DESC LIMIT $2 OFFSET $3`,
       [userSub, limit, offset],


### PR DESCRIPTION
Adds weather data tracking to GT3 ride uploads.

## Changes
- **Database**: Added 8 weather columns to `gt3_rides` table (temp, feels_like, humidity, wind_speed, wind_direction, condition, uv_index, pressure) using `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` for safe migration
- **POST /gt3/ride**: Accepts `weather` object in request body with temp, feelsLike, humidity, windSpeed, windDirection, condition, uvIndex, pressure
- **GET /gt3/rides**: Returns weather fields in list response
- **InfluxDB**: Weather metrics (temp, humidity, wind_speed) written to ride point for Grafana dashboards

## iOS Companion
The GT3 Companion app will be updated separately to fetch weather via WeatherKit and include it in ride uploads.