### PR TITLE
Add GT3 Pro web dashboard and scooter summary

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ scripts/
 docs/
 .eslintrs.js
 webpack.config.js
+src/public/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fluxhaus-server",
-  "version": "2.1.51",
+  "version": "2.1.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fluxhaus-server",
-      "version": "2.1.51",
+      "version": "2.1.52",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxhaus-server",
-  "version": "2.1.51",
+  "version": "2.1.52",
   "description": "",
   "main": "index.js",
   "type": "commonjs",

--- a/src/public/gt3/dashboard.js
+++ b/src/public/gt3/dashboard.js
@@ -39,7 +39,10 @@ async function apiFetch(path) {
 }
 
 const GEAR_NAMES = { 1: 'Eco', 2: 'Standard', 3: 'Sport', 4: 'Race' };
-function gearName(mode) { return GEAR_NAMES[mode] || `Mode ${mode}` || 'Unknown'; }
+function gearName(mode) {
+  if (mode == null) return 'Unknown';
+  return GEAR_NAMES[mode] || `Mode ${mode}`;
+}
 
 function formatDistance(km) {
   if (km == null) return '—';

--- a/src/public/gt3/dashboard.js
+++ b/src/public/gt3/dashboard.js
@@ -1,0 +1,257 @@
+// GT3 Pro Dashboard — Main page logic
+// Auth: relies on cookie-based session (same domain as fluxhaus-server)
+
+const API_BASE = '/gt3';
+let currentPage = 1;
+const PAGE_SIZE = 20;
+
+// Catppuccin Mocha chart palette
+const CHART_COLORS = {
+  sky: '#89dceb',
+  sapphire: '#74c7ec',
+  mauve: '#cba6f7',
+  green: '#a6e3a1',
+  peach: '#fab387',
+  red: '#f38ba8',
+  blue: '#89b4fa',
+  teal: '#94e2d5',
+  pink: '#f5c2e7',
+  yellow: '#f9e2af',
+  text: '#cdd6f4',
+  subtext: '#a6adc8',
+  surface: '#313244',
+  overlay: '#6c7086',
+};
+
+Chart.defaults.color = CHART_COLORS.subtext;
+Chart.defaults.borderColor = CHART_COLORS.surface;
+
+// ── Helpers ────────────────────────────────────────────────
+
+async function apiFetch(path) {
+  const res = await fetch(API_BASE + path, { credentials: 'include' });
+  if (res.status === 401) {
+    window.location.href = '/auth/login?redirect=' + encodeURIComponent(window.location.pathname);
+    return null;
+  }
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+const GEAR_NAMES = { 1: 'Eco', 2: 'Standard', 3: 'Sport', 4: 'Race' };
+function gearName(mode) { return GEAR_NAMES[mode] || `Mode ${mode}` || 'Unknown'; }
+
+function formatDistance(km) {
+  if (km == null) return '—';
+  return km < 1 ? `${(km * 1000).toFixed(0)} m` : `${km.toFixed(1)} km`;
+}
+
+function formatSpeed(kph) {
+  return kph != null ? `${kph.toFixed(1)} km/h` : '—';
+}
+
+function formatDate(iso) {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+    + ' ' + d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+}
+
+function formatDuration(startIso, endIso) {
+  if (!startIso || !endIso) return '—';
+  const ms = new Date(endIso) - new Date(startIso);
+  const min = Math.floor(ms / 60000);
+  return min < 60 ? `${min} min` : `${Math.floor(min / 60)}h ${min % 60}m`;
+}
+
+// Track chart instances so we can destroy before re-creating on pagination
+const chartInstances = {};
+
+function createChart(id, config) {
+  if (chartInstances[id]) {
+    chartInstances[id].destroy();
+  }
+  chartInstances[id] = new Chart(document.getElementById(id), config);
+}
+
+// ── Stats & Aggregate Charts ──────────────────────────────
+
+async function loadStats() {
+  const data = await apiFetch('/stats');
+  if (!data) return;
+  const s = data.summary;
+
+  document.getElementById('stats-overview').innerHTML = `
+    <div class="stat-card">
+      <div class="stat-value">${parseInt(s.total_rides)}</div>
+      <div class="stat-label">Total Rides</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${parseFloat(s.total_distance).toFixed(1)} km</div>
+      <div class="stat-label">Total Distance</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${parseFloat(s.avg_battery_per_km).toFixed(1)}%</div>
+      <div class="stat-label">Avg Battery/km</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${parseFloat(s.all_time_max_speed).toFixed(1)} km/h</div>
+      <div class="stat-label">Top Speed</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${parseFloat(s.overall_avg_speed).toFixed(1)} km/h</div>
+      <div class="stat-label">Avg Speed</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${parseFloat(s.avg_battery_per_ride).toFixed(0)}%</div>
+      <div class="stat-label">Avg Battery/Ride</div>
+    </div>
+  `;
+
+  // Monthly chart
+  if (data.monthly && data.monthly.length > 0) {
+    createChart('monthlyChart', {
+      type: 'bar',
+      data: {
+        labels: data.monthly.map(m => {
+          const d = new Date(m.month);
+          return d.toLocaleDateString(undefined, { month: 'short', year: '2-digit' });
+        }),
+        datasets: [{
+          label: 'Distance (km)',
+          data: data.monthly.map(m => parseFloat(m.distance)),
+          backgroundColor: CHART_COLORS.sky + '80',
+          borderColor: CHART_COLORS.sky,
+          borderWidth: 1,
+          yAxisID: 'y',
+        }, {
+          label: 'Rides',
+          data: data.monthly.map(m => parseInt(m.rides)),
+          backgroundColor: CHART_COLORS.mauve + '80',
+          borderColor: CHART_COLORS.mauve,
+          borderWidth: 1,
+          yAxisID: 'y1',
+        }],
+      },
+      options: {
+        responsive: true,
+        plugins: { legend: { position: 'top' } },
+        scales: {
+          y: { position: 'left', title: { display: true, text: 'Distance (km)' } },
+          y1: { position: 'right', title: { display: true, text: 'Rides' }, grid: { drawOnChartArea: false } },
+        },
+      },
+    });
+  }
+
+  // Gear mode chart
+  if (data.byGearMode && data.byGearMode.length > 0) {
+    createChart('gearChart', {
+      type: 'bar',
+      data: {
+        labels: data.byGearMode.map(g => gearName(g.gear_mode)),
+        datasets: [{
+          label: 'Avg Speed (km/h)',
+          data: data.byGearMode.map(g => parseFloat(g.avg_speed)),
+          backgroundColor: CHART_COLORS.sapphire + '80',
+          borderColor: CHART_COLORS.sapphire,
+          borderWidth: 1,
+        }, {
+          label: 'Battery/km (%)',
+          data: data.byGearMode.map(g => parseFloat(g.avg_battery_per_km)),
+          backgroundColor: CHART_COLORS.peach + '80',
+          borderColor: CHART_COLORS.peach,
+          borderWidth: 1,
+        }],
+      },
+      options: {
+        responsive: true,
+        plugins: { legend: { position: 'top' } },
+      },
+    });
+  }
+}
+
+// ── Rides Table & Per-Page Charts ─────────────────────────
+
+async function loadRides(page = 1) {
+  currentPage = page;
+  const data = await apiFetch(`/rides?page=${page}&limit=${PAGE_SIZE}`);
+  if (!data) return;
+
+  const tbody = document.getElementById('rides-body');
+  if (!data.rides || data.rides.length === 0) {
+    tbody.innerHTML = '<tr><td colspan="8" class="text-center text-muted" style="padding:2rem">No rides found</td></tr>';
+    return;
+  }
+
+  tbody.innerHTML = data.rides.map(r => `
+    <tr>
+      <td>${formatDate(r.start_time)}</td>
+      <td>${formatDistance(r.distance)}</td>
+      <td>${formatSpeed(r.max_speed)}</td>
+      <td>${formatSpeed(r.avg_speed)}</td>
+      <td><span class="battery-badge">${r.start_battery ?? '?'}% → ${r.end_battery ?? '?'}%</span></td>
+      <td><span class="gear-badge gear-${r.gear_mode}">${gearName(r.gear_mode)}</span></td>
+      <td>${r.weather_temp != null ? `${r.weather_temp.toFixed(0)}°C` : '—'}</td>
+      <td><a href="/gt3/ride.html?id=${r.id}" class="btn-small">Details →</a></td>
+    </tr>
+  `).join('');
+
+  // Distance & battery charts from current page rides
+  const rides = data.rides.slice().reverse();
+  if (rides.length > 1) {
+    createChart('distanceChart', {
+      type: 'line',
+      data: {
+        labels: rides.map(r => formatDate(r.start_time)),
+        datasets: [{
+          label: 'Distance (km)',
+          data: rides.map(r => r.distance),
+          borderColor: CHART_COLORS.sky,
+          backgroundColor: CHART_COLORS.sky + '20',
+          fill: true,
+          tension: 0.3,
+        }],
+      },
+      options: { responsive: true, plugins: { legend: { display: false } } },
+    });
+
+    createChart('batteryChart', {
+      type: 'line',
+      data: {
+        labels: rides.map(r => formatDate(r.start_time)),
+        datasets: [{
+          label: 'Battery Used (%)',
+          data: rides.map(r => r.battery_used),
+          borderColor: CHART_COLORS.peach,
+          backgroundColor: CHART_COLORS.peach + '20',
+          fill: true,
+          tension: 0.3,
+        }],
+      },
+      options: { responsive: true, plugins: { legend: { display: false } } },
+    });
+  }
+
+  // Pagination controls
+  const pag = document.getElementById('pagination');
+  pag.innerHTML = '';
+  if (page > 1) {
+    const prev = document.createElement('button');
+    prev.textContent = '← Previous';
+    prev.onclick = () => loadRides(page - 1);
+    pag.appendChild(prev);
+  }
+  if (data.rides.length === PAGE_SIZE) {
+    const next = document.createElement('button');
+    next.textContent = 'Next →';
+    next.onclick = () => loadRides(page + 1);
+    pag.appendChild(next);
+  }
+}
+
+// ── Init ──────────────────────────────────────────────────
+
+loadStats();
+loadRides();

--- a/src/public/gt3/index.html
+++ b/src/public/gt3/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GT3 Pro Dashboard</title>
+    <link rel="stylesheet" href="/gt3/style.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+</head>
+<body>
+    <header>
+        <h1>🛴 GT3 Pro Dashboard</h1>
+        <nav>
+            <a href="/gt3/" class="active">Dashboard</a>
+        </nav>
+    </header>
+    <main>
+        <!-- Stats Overview Cards -->
+        <section id="stats-overview" class="stats-grid">
+            <div class="stat-card"><div class="loading"><div class="spinner"></div></div></div>
+        </section>
+
+        <!-- Charts Section -->
+        <section class="charts-grid">
+            <div class="card">
+                <h3>Distance Over Time</h3>
+                <canvas id="distanceChart"></canvas>
+            </div>
+            <div class="card">
+                <h3>Battery Usage Per Ride</h3>
+                <canvas id="batteryChart"></canvas>
+            </div>
+            <div class="card">
+                <h3>Efficiency by Gear Mode</h3>
+                <canvas id="gearChart"></canvas>
+            </div>
+            <div class="card">
+                <h3>Monthly Summary</h3>
+                <canvas id="monthlyChart"></canvas>
+            </div>
+        </section>
+
+        <!-- Rides Table -->
+        <section class="card">
+            <h3>Recent Rides</h3>
+            <table id="rides-table">
+                <thead>
+                    <tr>
+                        <th>Date</th>
+                        <th>Distance</th>
+                        <th>Max Speed</th>
+                        <th>Avg Speed</th>
+                        <th>Battery</th>
+                        <th>Gear</th>
+                        <th>Weather</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody id="rides-body">
+                    <tr><td colspan="8" class="text-center text-muted" style="padding:2rem">Loading rides…</td></tr>
+                </tbody>
+            </table>
+            <div id="pagination" class="pagination"></div>
+        </section>
+    </main>
+    <script src="/gt3/dashboard.js"></script>
+</body>
+</html>

--- a/src/public/gt3/ride-detail.js
+++ b/src/public/gt3/ride-detail.js
@@ -1,0 +1,268 @@
+// GT3 Pro Dashboard — Ride detail page logic
+
+const API_BASE = '/gt3';
+
+const CHART_COLORS = {
+  sky: '#89dceb',
+  sapphire: '#74c7ec',
+  mauve: '#cba6f7',
+  green: '#a6e3a1',
+  peach: '#fab387',
+  red: '#f38ba8',
+  blue: '#89b4fa',
+  teal: '#94e2d5',
+  pink: '#f5c2e7',
+  yellow: '#f9e2af',
+  text: '#cdd6f4',
+  subtext: '#a6adc8',
+  surface: '#313244',
+};
+
+Chart.defaults.color = CHART_COLORS.subtext;
+Chart.defaults.borderColor = CHART_COLORS.surface;
+
+const GEAR_NAMES = { 1: 'Eco', 2: 'Standard', 3: 'Sport', 4: 'Race' };
+function gearName(mode) { return GEAR_NAMES[mode] || `Mode ${mode}` || 'Unknown'; }
+
+// ── Helpers ────────────────────────────────────────────────
+
+async function apiFetch(path) {
+  const res = await fetch(API_BASE + path, { credentials: 'include' });
+  if (res.status === 401) {
+    window.location.href = '/auth/login?redirect=' + encodeURIComponent(window.location.pathname);
+    return null;
+  }
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+function formatDate(iso) {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+    + ' ' + d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+}
+
+function formatDuration(startIso, endIso) {
+  if (!startIso || !endIso) return '—';
+  const ms = new Date(endIso) - new Date(startIso);
+  const min = Math.floor(ms / 60000);
+  return min < 60 ? `${min} min` : `${Math.floor(min / 60)}h ${min % 60}m`;
+}
+
+function formatTime(iso) {
+  if (!iso) return '';
+  return new Date(iso).toLocaleTimeString(undefined, {
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+  });
+}
+
+// ── Main ──────────────────────────────────────────────────
+
+async function loadRide() {
+  const params = new URLSearchParams(window.location.search);
+  const rideId = params.get('id');
+  if (!rideId) {
+    document.querySelector('main').innerHTML =
+      '<p class="error" style="margin:2rem">No ride ID specified. <a href="/gt3/">Return to dashboard</a></p>';
+    return;
+  }
+
+  const [ride, samplesData] = await Promise.all([
+    apiFetch(`/rides/${rideId}`),
+    apiFetch(`/rides/${rideId}/samples`).catch(() => null),
+  ]);
+  if (!ride) return;
+
+  document.title = `Ride ${formatDate(ride.start_time)} — GT3 Pro`;
+
+  // ── Ride info cards ─────────────────────────────────────
+  document.getElementById('ride-info').innerHTML = `
+    <div class="stat-card">
+      <div class="stat-value">${formatDate(ride.start_time)}</div>
+      <div class="stat-label">Date</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${formatDuration(ride.start_time, ride.end_time)}</div>
+      <div class="stat-label">Duration</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${ride.distance != null ? ride.distance.toFixed(1) + ' km' : '—'}</div>
+      <div class="stat-label">Distance</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${ride.max_speed != null ? ride.max_speed.toFixed(1) + ' km/h' : '—'}</div>
+      <div class="stat-label">Max Speed</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${ride.avg_speed != null ? ride.avg_speed.toFixed(1) + ' km/h' : '—'}</div>
+      <div class="stat-label">Avg Speed</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${ride.start_battery ?? '?'}% → ${ride.end_battery ?? '?'}%</div>
+      <div class="stat-label">Battery</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${gearName(ride.gear_mode)}</div>
+      <div class="stat-label">Gear Mode</div>
+    </div>
+    ${ride.weather_temp != null ? `
+    <div class="stat-card">
+      <div class="stat-value">${ride.weather_temp.toFixed(0)}°C ${ride.weather_condition || ''}</div>
+      <div class="stat-label">Weather</div>
+    </div>` : ''}
+  `;
+
+  // ── Map ─────────────────────────────────────────────────
+  if (ride.gps_track && Array.isArray(ride.gps_track) && ride.gps_track.length > 0) {
+    const map = L.map('map', { attributionControl: true });
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+      attribution: '&copy; OpenStreetMap contributors, &copy; CARTO',
+      maxZoom: 19,
+    }).addTo(map);
+
+    // gps_track: array of [lng, lat, alt?] (GeoJSON order) or {lat, lng} objects
+    const latLngs = ride.gps_track.map(coord => {
+      if (Array.isArray(coord)) return [coord[1], coord[0]];
+      return [coord.latitude || coord.lat, coord.longitude || coord.lng];
+    }).filter(c => c[0] && c[1]);
+
+    if (latLngs.length > 0) {
+      const polyline = L.polyline(latLngs, {
+        color: CHART_COLORS.sky, weight: 4, opacity: 0.8,
+      }).addTo(map);
+
+      L.circleMarker(latLngs[0], {
+        radius: 8, fillColor: CHART_COLORS.green,
+        color: '#fff', weight: 2, fillOpacity: 1,
+      }).addTo(map).bindPopup('Start');
+
+      L.circleMarker(latLngs[latLngs.length - 1], {
+        radius: 8, fillColor: CHART_COLORS.red,
+        color: '#fff', weight: 2, fillOpacity: 1,
+      }).addTo(map).bindPopup('End');
+
+      map.fitBounds(polyline.getBounds(), { padding: [30, 30] });
+    }
+  } else {
+    document.getElementById('map-section').style.display = 'none';
+  }
+
+  // ── Telemetry charts ────────────────────────────────────
+  if (samplesData && samplesData.samples && samplesData.samples.length > 0) {
+    const samples = samplesData.samples;
+    const times = samples.map(s => formatTime(s._time || s.time));
+
+    const chartOptions = {
+      responsive: true,
+      plugins: { legend: { position: 'top' } },
+      scales: { x: { display: true, ticks: { maxTicksLimit: 10 } } },
+      elements: { point: { radius: 0 }, line: { borderWidth: 2 } },
+    };
+
+    // Speed
+    new Chart(document.getElementById('speedChart'), {
+      type: 'line',
+      data: {
+        labels: times,
+        datasets: [{
+          label: 'Scooter Speed (km/h)',
+          data: samples.map(s => parseFloat(s.speed) || 0),
+          borderColor: CHART_COLORS.sky,
+          backgroundColor: CHART_COLORS.sky + '20',
+          fill: true, tension: 0.2,
+        }, {
+          label: 'GPS Speed (km/h)',
+          data: samples.map(s => parseFloat(s.gps_speed) || 0),
+          borderColor: CHART_COLORS.sapphire,
+          borderDash: [5, 5],
+          fill: false, tension: 0.2,
+        }],
+      },
+      options: chartOptions,
+    });
+
+    // Battery & BMS
+    new Chart(document.getElementById('batteryChart'), {
+      type: 'line',
+      data: {
+        labels: times,
+        datasets: [{
+          label: 'Battery (%)',
+          data: samples.map(s => parseFloat(s.battery) || 0),
+          borderColor: CHART_COLORS.green,
+          fill: false, tension: 0.2, yAxisID: 'y',
+        }, {
+          label: 'BMS Voltage (V)',
+          data: samples.map(s => parseFloat(s.bms_voltage) || 0),
+          borderColor: CHART_COLORS.yellow,
+          fill: false, tension: 0.2, yAxisID: 'y1',
+        }, {
+          label: 'BMS Current (A)',
+          data: samples.map(s => parseFloat(s.bms_current) || 0),
+          borderColor: CHART_COLORS.peach,
+          fill: false, tension: 0.2, yAxisID: 'y1',
+        }],
+      },
+      options: {
+        ...chartOptions,
+        scales: {
+          ...chartOptions.scales,
+          y: { position: 'left', title: { display: true, text: 'Battery %' }, min: 0, max: 100 },
+          y1: { position: 'right', title: { display: true, text: 'V / A' }, grid: { drawOnChartArea: false } },
+        },
+      },
+    });
+
+    // Altitude
+    const hasAlt = samples.some(s => {
+      const v = parseFloat(s.altitude);
+      return v && v !== 0;
+    });
+    if (hasAlt) {
+      new Chart(document.getElementById('altitudeChart'), {
+        type: 'line',
+        data: {
+          labels: times,
+          datasets: [{
+            label: 'Altitude (m)',
+            data: samples.map(s => parseFloat(s.altitude) || null),
+            borderColor: CHART_COLORS.teal,
+            backgroundColor: CHART_COLORS.teal + '20',
+            fill: true, tension: 0.3, spanGaps: true,
+          }],
+        },
+        options: chartOptions,
+      });
+    } else {
+      document.getElementById('altitudeChart').parentElement.style.display = 'none';
+    }
+
+    // Heart rate
+    const hrSamples = samples.filter(s => parseFloat(s.heart_rate) > 0);
+    if (hrSamples.length > 0) {
+      new Chart(document.getElementById('heartRateChart'), {
+        type: 'line',
+        data: {
+          labels: hrSamples.map(s => formatTime(s._time || s.time)),
+          datasets: [{
+            label: 'Heart Rate (bpm)',
+            data: hrSamples.map(s => parseFloat(s.heart_rate)),
+            borderColor: CHART_COLORS.red,
+            backgroundColor: CHART_COLORS.red + '20',
+            fill: true, tension: 0.3,
+          }],
+        },
+        options: chartOptions,
+      });
+    } else {
+      document.getElementById('heartRateChart').parentElement.style.display = 'none';
+    }
+  } else {
+    document.querySelectorAll('.charts-grid .card').forEach(card => {
+      card.innerHTML = '<p style="color: var(--subtext0); text-align: center; padding: 2rem;">No telemetry data available for this ride</p>';
+    });
+  }
+}
+
+loadRide();

--- a/src/public/gt3/ride-detail.js
+++ b/src/public/gt3/ride-detail.js
@@ -22,14 +22,17 @@ Chart.defaults.color = CHART_COLORS.subtext;
 Chart.defaults.borderColor = CHART_COLORS.surface;
 
 const GEAR_NAMES = { 1: 'Eco', 2: 'Standard', 3: 'Sport', 4: 'Race' };
-function gearName(mode) { return GEAR_NAMES[mode] || `Mode ${mode}` || 'Unknown'; }
+function gearName(mode) {
+  if (mode == null) return 'Unknown';
+  return GEAR_NAMES[mode] || `Mode ${mode}`;
+}
 
 // ── Helpers ────────────────────────────────────────────────
 
 async function apiFetch(path) {
   const res = await fetch(API_BASE + path, { credentials: 'include' });
   if (res.status === 401) {
-    window.location.href = '/auth/login?redirect=' + encodeURIComponent(window.location.pathname);
+    window.location.href = '/auth/login?redirect=' + encodeURIComponent(window.location.pathname + window.location.search);
     return null;
   }
   if (!res.ok) throw new Error(`API error: ${res.status}`);
@@ -124,8 +127,8 @@ async function loadRide() {
     // gps_track: array of [lng, lat, alt?] (GeoJSON order) or {lat, lng} objects
     const latLngs = ride.gps_track.map(coord => {
       if (Array.isArray(coord)) return [coord[1], coord[0]];
-      return [coord.latitude || coord.lat, coord.longitude || coord.lng];
-    }).filter(c => c[0] && c[1]);
+      return [coord.latitude ?? coord.lat, coord.longitude ?? coord.lng];
+    }).filter(c => Number.isFinite(c[0]) && Number.isFinite(c[1]));
 
     if (latLngs.length > 0) {
       const polyline = L.polyline(latLngs, {

--- a/src/public/gt3/ride.html
+++ b/src/public/gt3/ride.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ride Detail — GT3 Pro Dashboard</title>
+    <link rel="stylesheet" href="/gt3/style.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+</head>
+<body>
+    <header>
+        <h1>🛴 GT3 Pro Dashboard</h1>
+        <nav>
+            <a href="/gt3/">← Back to Dashboard</a>
+        </nav>
+    </header>
+    <main>
+        <section id="ride-info" class="stats-grid">
+            <div class="stat-card"><div class="loading"><div class="spinner"></div></div></div>
+        </section>
+
+        <section id="map-section" class="card">
+            <h3>Route</h3>
+            <div id="map" style="height: 400px; border-radius: 8px;"></div>
+        </section>
+
+        <section class="charts-grid">
+            <div class="card">
+                <h3>Speed</h3>
+                <canvas id="speedChart"></canvas>
+            </div>
+            <div class="card">
+                <h3>Battery &amp; BMS</h3>
+                <canvas id="batteryChart"></canvas>
+            </div>
+            <div class="card">
+                <h3>Altitude</h3>
+                <canvas id="altitudeChart"></canvas>
+            </div>
+            <div class="card">
+                <h3>Heart Rate</h3>
+                <canvas id="heartRateChart"></canvas>
+            </div>
+        </section>
+    </main>
+    <script src="/gt3/ride-detail.js"></script>
+</body>
+</html>

--- a/src/public/gt3/style.css
+++ b/src/public/gt3/style.css
@@ -1,0 +1,438 @@
+/* GT3 Pro Dashboard — Catppuccin Mocha Theme */
+
+/* ── CSS Custom Properties ─────────────────────────────────── */
+:root {
+  --base: #1e1e2e;
+  --mantle: #181825;
+  --crust: #11111b;
+  --surface0: #313244;
+  --surface1: #45475a;
+  --surface2: #585b70;
+  --text: #cdd6f4;
+  --subtext1: #bac2de;
+  --subtext0: #a6adc8;
+  --overlay0: #6c7086;
+  --overlay1: #7f849c;
+  --sky: #89dceb;
+  --sapphire: #74c7ec;
+  --green: #a6e3a1;
+  --red: #f38ba8;
+  --yellow: #f9e2af;
+  --peach: #fab387;
+  --mauve: #cba6f7;
+  --blue: #89b4fa;
+  --teal: #94e2d5;
+  --pink: #f5c2e7;
+  --flamingo: #f2cdcd;
+  --rosewater: #f5e0dc;
+  --radius: 12px;
+  --radius-sm: 6px;
+  --transition: 150ms ease;
+}
+
+/* ── Reset / Normalize ─────────────────────────────────────── */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+  -moz-tab-size: 4;
+  tab-size: 4;
+  scroll-behavior: smooth;
+}
+
+body {
+  background: var(--base);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, sans-serif;
+  font-size: 15px;
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+img, svg, canvas {
+  display: block;
+  max-width: 100%;
+}
+
+a {
+  color: var(--sky);
+  text-decoration: none;
+  transition: color var(--transition);
+}
+
+a:hover {
+  color: var(--sapphire);
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+/* ── Header / Navigation ───────────────────────────────────── */
+header {
+  background: var(--mantle);
+  border-bottom: 1px solid var(--surface0);
+  padding: 0.75rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+header h1 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text);
+  white-space: nowrap;
+}
+
+header nav {
+  display: flex;
+  gap: 1rem;
+}
+
+header nav a {
+  color: var(--subtext0);
+  font-size: 0.9rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-sm);
+  transition: background var(--transition), color var(--transition);
+}
+
+header nav a:hover,
+header nav a.active {
+  color: var(--sky);
+  background: var(--surface0);
+}
+
+/* ── Main Layout ───────────────────────────────────────────── */
+main {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+/* ── Cards ─────────────────────────────────────────────────── */
+.card {
+  background: var(--mantle);
+  border: 1px solid var(--surface0);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+}
+
+.card h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--subtext1);
+  margin-bottom: 1rem;
+}
+
+/* ── Stats Grid ────────────────────────────────────────────── */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+}
+
+.stat-card {
+  background: var(--mantle);
+  border: 1px solid var(--surface0);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  text-align: center;
+  transition: border-color var(--transition);
+}
+
+.stat-card:hover {
+  border-color: var(--surface1);
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--sky);
+  line-height: 1.2;
+  margin-bottom: 0.25rem;
+}
+
+.stat-label {
+  font-size: 0.8rem;
+  color: var(--subtext0);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* ── Charts Grid ───────────────────────────────────────────── */
+.charts-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.25rem;
+}
+
+@media (max-width: 768px) {
+  .charts-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Tables ────────────────────────────────────────────────── */
+.table-wrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+table {
+  font-size: 0.9rem;
+}
+
+thead th {
+  text-align: left;
+  padding: 0.65rem 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--subtext0);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 2px solid var(--surface0);
+  white-space: nowrap;
+}
+
+tbody tr {
+  transition: background var(--transition);
+}
+
+tbody tr:nth-child(odd) {
+  background: var(--mantle);
+}
+
+tbody tr:nth-child(even) {
+  background: var(--surface0);
+}
+
+tbody tr:hover {
+  background: var(--surface1);
+}
+
+tbody td {
+  padding: 0.6rem 0.75rem;
+  white-space: nowrap;
+  color: var(--subtext1);
+}
+
+/* Mobile table scroll */
+@media (max-width: 768px) {
+  .card:has(table) {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 700px;
+  }
+}
+
+/* ── Buttons ───────────────────────────────────────────────── */
+button,
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.55rem 1.1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--sky);
+  color: var(--crust);
+  cursor: pointer;
+  transition: background var(--transition), transform var(--transition);
+}
+
+button:hover,
+.btn:hover {
+  background: var(--sapphire);
+}
+
+button:active,
+.btn:active {
+  transform: scale(0.97);
+}
+
+.btn-small {
+  display: inline-block;
+  padding: 0.3rem 0.7rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  background: var(--surface0);
+  color: var(--sky);
+  transition: background var(--transition), color var(--transition);
+}
+
+.btn-small:hover {
+  background: var(--surface1);
+  color: var(--sapphire);
+}
+
+/* ── Form Inputs ───────────────────────────────────────────── */
+input,
+select,
+textarea {
+  background: var(--surface0);
+  color: var(--text);
+  border: 1px solid var(--surface1);
+  border-radius: var(--radius-sm);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9rem;
+  font-family: inherit;
+  outline: none;
+  transition: border-color var(--transition);
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--sky);
+}
+
+/* ── Badges / Pills ────────────────────────────────────────── */
+.gear-badge {
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.gear-1 { background: var(--green); color: var(--crust); }       /* Eco */
+.gear-2 { background: var(--blue); color: var(--crust); }        /* Standard */
+.gear-3 { background: var(--peach); color: var(--crust); }       /* Sport */
+.gear-4 { background: var(--red); color: var(--crust); }         /* Race */
+.gear-undefined,
+.gear-null { background: var(--overlay0); color: var(--crust); } /* Unknown */
+
+.battery-badge {
+  font-size: 0.85rem;
+  color: var(--green);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Pagination ────────────────────────────────────────────── */
+.pagination {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+/* ── Map Container (Leaflet) ───────────────────────────────── */
+#map {
+  height: 400px;
+  border-radius: 8px;
+  z-index: 1;
+  background: var(--surface0);
+}
+
+/* Leaflet overrides for dark theme */
+.leaflet-control-attribution {
+  background: var(--mantle) !important;
+  color: var(--overlay0) !important;
+  font-size: 0.7rem !important;
+}
+
+.leaflet-control-attribution a {
+  color: var(--subtext0) !important;
+}
+
+.leaflet-control-zoom a {
+  background: var(--mantle) !important;
+  color: var(--text) !important;
+  border-color: var(--surface0) !important;
+}
+
+.leaflet-control-zoom a:hover {
+  background: var(--surface0) !important;
+}
+
+/* ── Loading Spinner ───────────────────────────────────────── */
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem;
+}
+
+.spinner {
+  width: 36px;
+  height: 36px;
+  border: 3px solid var(--surface0);
+  border-top-color: var(--sky);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── Error State ───────────────────────────────────────────── */
+.error {
+  color: var(--red);
+  background: rgba(243, 139, 168, 0.1);
+  border: 1px solid var(--red);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+}
+
+/* ── Utility ───────────────────────────────────────────────── */
+.text-muted {
+  color: var(--subtext0);
+}
+
+.text-center {
+  text-align: center;
+}
+
+/* ── Responsive ────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  header {
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: flex-start;
+  }
+
+  main {
+    padding: 1rem;
+    gap: 1rem;
+  }
+
+  .stats-grid {
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  }
+
+  .stat-value {
+    font-size: 1.2rem;
+  }
+
+  #map {
+    height: 280px;
+  }
+}

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -1,7 +1,15 @@
 import { Router } from 'express';
 import { getPool } from '../db';
 import { writePoint } from '../influx';
+import { InfluxDBClient } from '../clients/influxdb';
 import logger from '../logger';
+
+const influxQuery = new InfluxDBClient({
+  url: (process.env.INFLUXDB_URL || '').trim(),
+  token: (process.env.INFLUXDB_TOKEN || '').trim(),
+  org: (process.env.INFLUXDB_ORG || 'fluxhaus').trim(),
+  bucket: (process.env.INFLUXDB_BUCKET || 'fluxhaus').trim(),
+});
 
 const gt3Logger = logger.child({ subsystem: 'gt3' });
 
@@ -213,6 +221,98 @@ router.get('/status', async (req, res) => {
     return res.json(result.rows[0] || null);
   } catch (err) {
     gt3Logger.error({ err }, 'Failed to get status');
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// GET /gt3/rides/:id/samples — telemetry samples for charting
+router.get('/rides/:id/samples', async (req, res) => {
+  const pool = getPool();
+  if (!pool) return res.status(503).json({ error: 'Database unavailable' });
+  try {
+    const userSub = req.user?.sub || 'unknown';
+    // Get the ride's time range from PostgreSQL
+    const rideResult = await pool.query(
+      'SELECT start_time, end_time FROM gt3_rides WHERE id = $1 AND user_sub = $2',
+      [req.params.id, userSub],
+    );
+    if (rideResult.rows.length === 0) return res.status(404).json({ error: 'Ride not found' });
+    const { start_time: startTime, end_time: endTime } = rideResult.rows[0];
+
+    if (!influxQuery.configured) {
+      return res.status(503).json({ error: 'InfluxDB not configured' });
+    }
+
+    const startISO = new Date(startTime).toISOString();
+    const endISO = endTime ? new Date(endTime).toISOString() : new Date().toISOString();
+
+    const flux = `from(bucket: "${(process.env.INFLUXDB_BUCKET || 'fluxhaus').trim()}")
+  |> range(start: ${startISO}, stop: ${endISO})
+  |> filter(fn: (r) => r._measurement == "gt3_telemetry")
+  |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
+  |> sort(columns: ["_time"])`;
+
+    const samples = await influxQuery.query(flux);
+    return res.json({ samples, rideId: req.params.id });
+  } catch (err) {
+    gt3Logger.error({ err }, 'Failed to get ride samples');
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// GET /gt3/stats — aggregate ride statistics
+router.get('/stats', async (req, res) => {
+  const pool = getPool();
+  if (!pool) return res.status(503).json({ error: 'Database unavailable' });
+  try {
+    const userSub = req.user?.sub || 'unknown';
+    const result = await pool.query(
+      `SELECT
+        COUNT(*) as total_rides,
+        COALESCE(SUM(distance), 0) as total_distance,
+        COALESCE(AVG(avg_speed), 0) as overall_avg_speed,
+        COALESCE(MAX(max_speed), 0) as all_time_max_speed,
+        COALESCE(AVG(battery_used), 0) as avg_battery_per_ride,
+        COALESCE(AVG(CASE WHEN distance > 0
+          THEN battery_used::float / distance ELSE NULL END), 0) as avg_battery_per_km,
+        COALESCE(MIN(start_time), NOW()) as first_ride,
+        COALESCE(MAX(start_time), NOW()) as last_ride
+      FROM gt3_rides WHERE user_sub = $1`,
+      [userSub],
+    );
+    // Monthly breakdown
+    const monthly = await pool.query(
+      `SELECT
+        date_trunc('month', start_time) as month,
+        COUNT(*) as rides,
+        COALESCE(SUM(distance), 0) as distance,
+        COALESCE(AVG(avg_speed), 0) as avg_speed,
+        COALESCE(AVG(battery_used), 0) as avg_battery_used
+      FROM gt3_rides WHERE user_sub = $1
+      GROUP BY date_trunc('month', start_time)
+      ORDER BY month`,
+      [userSub],
+    );
+    // By gear mode
+    const byGear = await pool.query(
+      `SELECT
+        gear_mode,
+        COUNT(*) as rides,
+        COALESCE(AVG(avg_speed), 0) as avg_speed,
+        COALESCE(AVG(battery_used), 0) as avg_battery_used,
+        COALESCE(AVG(CASE WHEN distance > 0 THEN battery_used::float / distance ELSE NULL END), 0) as avg_battery_per_km
+      FROM gt3_rides WHERE user_sub = $1 AND gear_mode IS NOT NULL
+      GROUP BY gear_mode
+      ORDER BY gear_mode`,
+      [userSub],
+    );
+    return res.json({
+      summary: result.rows[0],
+      monthly: monthly.rows,
+      byGearMode: byGear.rows,
+    });
+  } catch (err) {
+    gt3Logger.error({ err }, 'Failed to get stats');
     return res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -249,6 +249,7 @@ router.get('/rides/:id/samples', async (req, res) => {
     const flux = `from(bucket: "${(process.env.INFLUXDB_BUCKET || 'fluxhaus').trim()}")
   |> range(start: ${startISO}, stop: ${endISO})
   |> filter(fn: (r) => r._measurement == "gt3_telemetry")
+  |> filter(fn: (r) => r.scooter == "GT3Pro")
   |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
   |> sort(columns: ["_time"])`;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import fs from 'fs';
+import path from 'path';
 import express, { Express } from 'express';
 import cookieParser from 'cookie-parser';
 import session from 'express-session';
@@ -188,6 +189,9 @@ export async function createServer(): Promise<Express> {
     });
   });
 
+  // Serve static files (HTML/JS/CSS dashboards) — no auth required
+  app.use(express.static(path.join(__dirname, 'public')));
+
   // OIDC auth routes (login, callback, logout) — unauthenticated
   app.use(createAuthRouter());
 
@@ -373,10 +377,54 @@ export async function createServer(): Promise<Express> {
     calendar,
   };
 
-  app.get('/', cors(corsOptions), (req, res) => {
+  app.get('/', cors(corsOptions), async (req, res) => {
     res.setHeader('Content-Type', 'application/json');
     const evStatus = car.status?.evStatus ?? null;
     const role = req.user?.role;
+
+    let scooterSummary = null;
+    const dbPool = getPool();
+    if (dbPool) {
+      try {
+        const [snapshotResult, lastRideResult] = await Promise.all([
+          dbPool.query(
+            `SELECT odometer, total_ride_time, bms1_cycle_count, bms2_cycle_count, timestamp
+             FROM gt3_snapshots WHERE user_sub = $1 ORDER BY timestamp DESC LIMIT 1`,
+            [req.user?.sub || 'unknown'],
+          ),
+          dbPool.query(
+            `SELECT start_time, end_time, distance, max_speed, avg_speed,
+               battery_used, start_battery, end_battery, gear_mode
+             FROM gt3_rides WHERE user_sub = $1 ORDER BY start_time DESC LIMIT 1`,
+            [req.user?.sub || 'unknown'],
+          ),
+        ]);
+        const snapshot = snapshotResult.rows[0];
+        const lastRide = lastRideResult.rows[0];
+        if (snapshot || lastRide) {
+          scooterSummary = {
+            timestamp: snapshot?.timestamp || new Date().toISOString(),
+            odometer: snapshot?.odometer ?? null,
+            totalRideTime: snapshot?.total_ride_time ?? null,
+            batteryCycles: (snapshot?.bms1_cycle_count ?? 0) + (snapshot?.bms2_cycle_count ?? 0),
+            lastRide: lastRide ? {
+              date: lastRide.start_time,
+              endDate: lastRide.end_time,
+              distance: lastRide.distance,
+              maxSpeed: lastRide.max_speed,
+              avgSpeed: lastRide.avg_speed,
+              batteryUsed: lastRide.battery_used,
+              startBattery: lastRide.start_battery,
+              endBattery: lastRide.end_battery,
+              gearMode: lastRide.gear_mode,
+            } : null,
+          };
+        }
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      } catch (_err) {
+        // Non-fatal — just skip scooter data
+      }
+    }
 
     let rhizomeSchedule = null;
     if (fs.existsSync('cache/rhizome.json')) {
@@ -450,6 +498,7 @@ export async function createServer(): Promise<Express> {
         car: car.status,
         carEvStatus: evStatus,
         carOdometer: car.odometer,
+        scooter: scooterSummary,
         cameraURL,
         romperURL,
         gymURL,
@@ -512,6 +561,7 @@ export async function createServer(): Promise<Express> {
         car: car.status,
         carEvStatus: evStatus,
         carOdometer: car.odometer,
+        scooter: scooterSummary,
         miele,
         homeConnect,
         dishwasher: dishwasher.dishwasher,

--- a/src/server.ts
+++ b/src/server.ts
@@ -384,19 +384,20 @@ export async function createServer(): Promise<Express> {
 
     let scooterSummary = null;
     const dbPool = getPool();
-    if (dbPool) {
+    if (dbPool && req.user?.sub) {
       try {
+        const userSub = req.user.sub;
         const [snapshotResult, lastRideResult] = await Promise.all([
           dbPool.query(
             `SELECT odometer, total_ride_time, bms1_cycle_count, bms2_cycle_count, timestamp
              FROM gt3_snapshots WHERE user_sub = $1 ORDER BY timestamp DESC LIMIT 1`,
-            [req.user?.sub || 'unknown'],
+            [userSub],
           ),
           dbPool.query(
             `SELECT start_time, end_time, distance, max_speed, avg_speed,
                battery_used, start_battery, end_battery, gear_mode
              FROM gt3_rides WHERE user_sub = $1 ORDER BY start_time DESC LIMIT 1`,
-            [req.user?.sub || 'unknown'],
+            [userSub],
           ),
         ]);
         const snapshot = snapshotResult.rows[0];

--- a/src/server.ts
+++ b/src/server.ts
@@ -190,7 +190,7 @@ export async function createServer(): Promise<Express> {
   });
 
   // Serve static files (HTML/JS/CSS dashboards) — no auth required
-  app.use(express.static(path.join(__dirname, 'public')));
+  app.use('/gt3', express.static(path.join(__dirname, 'public', 'gt3')));
 
   // OIDC auth routes (login, callback, logout) — unauthenticated
   app.use(createAuthRouter());


### PR DESCRIPTION
## Summary

Adds a web-based GT3 Pro ride dashboard and includes scooter data in the main API response.

### Web Dashboard (`/gt3/`)
- **Dashboard page** with stats overview cards, monthly distance/rides chart, gear mode efficiency chart, battery & distance per ride charts, and a paginated ride table
- **Ride detail page** with speed, battery/BMS, altitude, and heart rate time-series charts plus a dark-themed Leaflet GPS route map
- Catppuccin Mocha dark theme CSS

### New API Endpoints
- `GET /gt3/stats` — aggregate ride statistics with monthly and gear-mode breakdowns
- `GET /gt3/rides/:id/samples` — InfluxDB telemetry samples for time-series charting

### Scooter Summary in LoginResponse
- `GET /` now includes a `scooter` field (odometer, last ride summary, battery cycles, total ride time) for admin/demo roles, queried per-user from PostgreSQL

### Files Changed
- `src/server.ts` — static file serving, async GET /, scooter summary queries
- `src/routes/gt3.routes.ts` — samples and stats endpoints
- `src/public/gt3/` — 5 new static files (HTML, CSS, JS)