### PR TITLE
Feature/gt3 web dashboard

### DIFF
--- a/src/__tests__/push-token-store.test.ts
+++ b/src/__tests__/push-token-store.test.ts
@@ -3,6 +3,9 @@ import {
   deletePushToken,
   getAllActivePushTokens,
   getAllDeviceTokens,
+  getApnsTokensByUser,
+  getDeviceTokensByUser,
+  getDeviceTokensByUserAndBundle,
   getPushTokensByActivityType,
   saveDeviceToken,
   savePushToken,
@@ -168,6 +171,87 @@ describe('push-token-store', () => {
       (getPool as jest.Mock).mockReturnValueOnce(null);
       await deleteDeviceToken('device-tok-xyz');
       expect(mockQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getDeviceTokensByUserAndBundle', () => {
+    it('returns device tokens filtered by user and bundle', async () => {
+      mockQuery.mockResolvedValue({
+        rows: [
+          {
+            userSub: 'user-123',
+            deviceName: 'iPhone 15',
+            pushToStartToken: 'tok-1',
+            bundleId: 'org.davidjensenius.GT3Companion',
+          },
+        ],
+      });
+      const result = await getDeviceTokensByUserAndBundle(
+        'user-123',
+        'org.davidjensenius.GT3Companion',
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].pushToStartToken).toBe('tok-1');
+      expect(mockQuery.mock.calls[0][1]).toEqual([
+        'user-123',
+        'org.davidjensenius.GT3Companion',
+      ]);
+    });
+
+    it('returns empty array when pool is null', async () => {
+      (getPool as jest.Mock).mockReturnValueOnce(null);
+      const result = await getDeviceTokensByUserAndBundle('user-123', 'bundle');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getApnsTokensByUser', () => {
+    it('returns APNs tokens for a user', async () => {
+      mockQuery.mockResolvedValue({
+        rows: [
+          {
+            userSub: 'user-123',
+            deviceName: 'iPhone 15',
+            token: 'apns-tok-1',
+            bundleId: 'org.davidjensenius.FluxHaus',
+          },
+        ],
+      });
+      const result = await getApnsTokensByUser('user-123');
+      expect(result).toHaveLength(1);
+      expect(result[0].token).toBe('apns-tok-1');
+      expect(mockQuery.mock.calls[0][1]).toEqual(['user-123']);
+    });
+
+    it('returns empty array when pool is null', async () => {
+      (getPool as jest.Mock).mockReturnValueOnce(null);
+      const result = await getApnsTokensByUser('user-123');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getDeviceTokensByUser', () => {
+    it('returns all device tokens for a user', async () => {
+      mockQuery.mockResolvedValue({
+        rows: [
+          {
+            userSub: 'user-123',
+            deviceName: 'iPhone 15',
+            pushToStartToken: 'dev-tok-1',
+            bundleId: 'org.davidjensenius.FluxHaus',
+          },
+        ],
+      });
+      const result = await getDeviceTokensByUser('user-123');
+      expect(result).toHaveLength(1);
+      expect(result[0].pushToStartToken).toBe('dev-tok-1');
+      expect(mockQuery.mock.calls[0][1]).toEqual(['user-123']);
+    });
+
+    it('returns empty array when pool is null', async () => {
+      (getPool as jest.Mock).mockReturnValueOnce(null);
+      const result = await getDeviceTokensByUser('user-123');
+      expect(result).toEqual([]);
     });
   });
 });

--- a/src/apns.ts
+++ b/src/apns.ts
@@ -201,6 +201,76 @@ export async function sendPushToStart(
 /**
  * @deprecated Use multiDevicePushToStartAll for the consolidated activity.
  */
+/**
+ * Send a push-to-start notification to create a GT3 Companion Live Activity.
+ * Uses the GT3 bundle ID and GT3RideAttributes type.
+ */
+export async function sendGT3PushToStart(
+  deviceToken: string,
+  contentState: Record<string, unknown>,
+): Promise<boolean> {
+  if (!provider) {
+    apnsLogger.debug('APNs not initialized — skipping GT3 push-to-start');
+    return false;
+  }
+
+  const bundleId = 'org.davidjensenius.GT3Companion';
+
+  const notification = new apn.Notification();
+  notification.topic = `${bundleId}.push-type.liveactivity`;
+  notification.pushType = 'liveactivity';
+  notification.priority = 10;
+  notification.expiry = Math.floor(Date.now() / 1000) + 3600;
+
+  notification.rawPayload = {
+    aps: {
+      timestamp: Math.floor(Date.now() / 1000),
+      event: 'start',
+      'content-state': contentState,
+      'stale-date': Math.floor(Date.now() / 1000) + 300,
+      'attributes-type': 'GT3RideAttributes',
+      attributes: {
+        scooterName: 'GT3 Pro',
+        startTime: new Date().toISOString(),
+      },
+      alert: {
+        title: 'GT3 Pro Connected',
+        body: 'Ride tracking active',
+      },
+    },
+  };
+
+  try {
+    const result = await provider.send(notification, deviceToken);
+    apnsLogger.info(
+      {
+        sent: result.sent?.length ?? 0,
+        failed: result.failed?.length ?? 0,
+        failureReasons: result.failed?.map(
+          (f: { response?: { reason?: string } }) => f.response?.reason,
+        ),
+      },
+      'GT3 push-to-start result',
+    );
+    if (result.failed.length > 0) {
+      const failure = result.failed[0];
+      const reason = failure.response?.reason || 'unknown';
+      apnsLogger.warn({ reason }, 'GT3 push-to-start failed');
+
+      if (reason === 'BadDeviceToken' || reason === 'Unregistered' || reason === 'ExpiredToken') {
+        await deleteDeviceToken(deviceToken);
+        apnsLogger.info('Removed invalid GT3 push-to-start token');
+      }
+      return false;
+    }
+    apnsLogger.info('GT3 push-to-start sent successfully');
+    return true;
+  } catch (err) {
+    apnsLogger.error({ err }, 'GT3 push-to-start send error');
+    return false;
+  }
+}
+
 export async function pushToStartAll(
   deviceTokens: Array<{ pushToStartToken: string }>,
   contentState: LiveActivityContentState,

--- a/src/apns.ts
+++ b/src/apns.ts
@@ -199,9 +199,6 @@ export async function sendPushToStart(
 }
 
 /**
- * @deprecated Use multiDevicePushToStartAll for the consolidated activity.
- */
-/**
  * Send a push-to-start notification to create a GT3 Companion Live Activity.
  * Uses the GT3 bundle ID and GT3RideAttributes type.
  */
@@ -586,10 +583,11 @@ export async function sendAlertNotification(
   title: string,
   body: string,
   category?: string,
+  topic?: string,
 ): Promise<boolean> {
   if (!provider) return false;
 
-  const bundleId = process.env.APNS_BUNDLE_ID || 'org.davidjensenius.FluxHaus';
+  const bundleId = topic || process.env.APNS_BUNDLE_ID || 'org.davidjensenius.FluxHaus';
   const notification = new apn.Notification();
   notification.topic = bundleId;
   notification.sound = 'default';

--- a/src/push-token-store.ts
+++ b/src/push-token-store.ts
@@ -231,6 +231,43 @@ export async function deleteApnsToken(token: string): Promise<void> {
   }
 }
 
+export async function getApnsTokensByUser(userSub: string): Promise<ApnsTokenData[]> {
+  const pool = getPool();
+  if (!pool) return [];
+
+  try {
+    const result = await pool.query(
+      `SELECT user_sub AS "userSub", device_name AS "deviceName",
+              token, bundle_id AS "bundleId"
+       FROM apns_tokens WHERE user_sub = $1`,
+      [userSub],
+    );
+    return result.rows;
+  } catch (err) {
+    pushLogger.error({ err, userSub }, 'Failed to get APNs tokens by user');
+    return [];
+  }
+}
+
+export async function getDeviceTokensByUser(userSub: string): Promise<DeviceTokenData[]> {
+  const pool = getPool();
+  if (!pool) return [];
+
+  try {
+    const result = await pool.query(
+      `SELECT user_sub AS "userSub", device_name AS "deviceName",
+              push_to_start_token AS "pushToStartToken",
+              bundle_id AS "bundleId"
+       FROM device_tokens WHERE user_sub = $1`,
+      [userSub],
+    );
+    return result.rows;
+  } catch (err) {
+    pushLogger.error({ err, userSub }, 'Failed to get device tokens by user');
+    return [];
+  }
+}
+
 // --- Per-activity Live Activity push tokens (for direct token-based updates) ---
 
 export interface ActivityTokenData {

--- a/src/push-token-store.ts
+++ b/src/push-token-store.ts
@@ -136,6 +136,29 @@ export async function getAllDeviceTokens(): Promise<DeviceTokenData[]> {
   }
 }
 
+export async function getDeviceTokensByUserAndBundle(
+  userSub: string,
+  bundleId: string,
+): Promise<DeviceTokenData[]> {
+  const pool = getPool();
+  if (!pool) return [];
+
+  try {
+    const result = await pool.query(
+      `SELECT user_sub AS "userSub", device_name AS "deviceName",
+              push_to_start_token AS "pushToStartToken",
+              bundle_id AS "bundleId"
+       FROM device_tokens
+       WHERE user_sub = $1 AND bundle_id = $2`,
+      [userSub, bundleId],
+    );
+    return result.rows;
+  } catch (err) {
+    pushLogger.error({ err, userSub, bundleId }, 'Failed to get device tokens by user/bundle');
+    return [];
+  }
+}
+
 export async function deleteDeviceToken(pushToStartToken: string): Promise<void> {
   const pool = getPool();
   if (!pool) return;

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -3,6 +3,8 @@ import { getPool } from '../db';
 import { writePoint } from '../influx';
 import { InfluxDBClient } from '../clients/influxdb';
 import logger from '../logger';
+import { sendGT3PushToStart } from '../apns';
+import { getDeviceTokensByUserAndBundle } from '../push-token-store';
 
 const influxQuery = new InfluxDBClient({
   url: (process.env.INFLUXDB_URL || '').trim(),
@@ -314,6 +316,50 @@ router.get('/stats', async (req, res) => {
     });
   } catch (err) {
     gt3Logger.error({ err }, 'Failed to get stats');
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// --- Live Activity push-to-start ---
+
+router.post('/activity/start', async (req, res) => {
+  const userSub = req.user?.sub;
+  if (!userSub) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const gt3BundleId = 'org.davidjensenius.GT3Companion';
+  try {
+    const tokens = await getDeviceTokensByUserAndBundle(userSub, gt3BundleId);
+    if (tokens.length === 0) {
+      gt3Logger.warn({ userSub }, 'No GT3 push-to-start tokens found');
+      return res.status(404).json({ error: 'No push-to-start token registered' });
+    }
+
+    const contentState = {
+      speed: 0,
+      battery: 0,
+      tripDistance: 0,
+      estimatedRange: 0,
+      gearMode: 0,
+      bmsTemp: 0,
+      isCharging: false,
+      isAwake: false,
+      isConnected: true,
+    };
+
+    const results = await Promise.allSettled(
+      tokens.map((t) => sendGT3PushToStart(t.pushToStartToken, contentState)),
+    );
+
+    const sent = results.filter(
+      (r) => r.status === 'fulfilled' && r.value === true,
+    ).length;
+
+    gt3Logger.info({ userSub, sent, total: tokens.length }, 'GT3 push-to-start dispatched');
+    return res.json({ success: sent > 0, sent, total: tokens.length });
+  } catch (err) {
+    gt3Logger.error({ err, userSub }, 'Failed to send GT3 push-to-start');
     return res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/src/routes/push.routes.ts
+++ b/src/routes/push.routes.ts
@@ -9,6 +9,7 @@ import { onPushToStartTokenRegistered } from '../live-activity-hooks';
 import {
   sendAlertNotification, sendGT3PushToStart, sendPushToStart,
 } from '../apns';
+import { requireRole } from '../middleware/auth.middleware';
 import logger from '../logger';
 
 const pushLogger = logger.child({ subsystem: 'push-routes' });
@@ -54,7 +55,7 @@ router.post('/push-tokens/device', async (req, res) => {
     return;
   }
 
-  const { pushToStartToken, deviceName } = req.body;
+  const { pushToStartToken, deviceName, bundleId } = req.body;
   if (!pushToStartToken) {
     res.status(400).json({ error: 'pushToStartToken is required' });
     return;
@@ -65,7 +66,7 @@ router.post('/push-tokens/device', async (req, res) => {
       userSub,
       pushToStartToken,
       deviceName,
-      bundleId: process.env.APNS_BUNDLE_ID || 'org.davidjensenius.FluxHaus',
+      bundleId: bundleId || process.env.APNS_BUNDLE_ID || 'org.davidjensenius.FluxHaus',
     });
     pushLogger.info({ userSub }, 'Device push-to-start token registered');
     res.json({ success: true });
@@ -196,9 +197,9 @@ router.post('/push-tokens/subscriptions', async (req, res) => {
   }
 });
 
-// --- Test push notification endpoints ---
+// --- Test push notification endpoints (admin only) ---
 
-router.get('/push-test/tokens', async (req, res) => {
+router.get('/push-test/tokens', requireRole('admin'), async (req, res) => {
   const userSub = req.user?.sub;
   if (!userSub) {
     res.status(401).json({ error: 'Unauthorized' });
@@ -228,7 +229,7 @@ router.get('/push-test/tokens', async (req, res) => {
   }
 });
 
-router.post('/push-test/alert', async (req, res) => {
+router.post('/push-test/alert', requireRole('admin'), async (req, res) => {
   const userSub = req.user?.sub;
   if (!userSub) {
     res.status(401).json({ error: 'Unauthorized' });
@@ -255,6 +256,8 @@ router.post('/push-test/alert', async (req, res) => {
         t.token,
         title || 'Test Notification',
         body || 'This is a test push from FluxHaus Server',
+        undefined,
+        t.bundleId,
       )),
     );
 
@@ -267,7 +270,7 @@ router.post('/push-test/alert', async (req, res) => {
   }
 });
 
-router.post('/push-test/push-to-start', async (req, res) => {
+router.post('/push-test/push-to-start', requireRole('admin'), async (req, res) => {
   const userSub = req.user?.sub;
   if (!userSub) {
     res.status(401).json({ error: 'Unauthorized' });

--- a/src/routes/push.routes.ts
+++ b/src/routes/push.routes.ts
@@ -1,10 +1,14 @@
 import { Router } from 'express';
 import {
-  deleteDeviceToken, saveActivityToken, saveApnsToken, saveDeviceToken,
+  deleteDeviceToken, getApnsTokensByUser, getDeviceTokensByUser,
+  saveActivityToken, saveApnsToken, saveDeviceToken,
 } from '../push-token-store';
 import { getAllChannels, getChannelId } from '../apns-channels';
 import { getSubscriptions, saveSubscriptions } from '../la-subscriptions';
 import { onPushToStartTokenRegistered } from '../live-activity-hooks';
+import {
+  sendAlertNotification, sendGT3PushToStart, sendPushToStart,
+} from '../apns';
 import logger from '../logger';
 
 const pushLogger = logger.child({ subsystem: 'push-routes' });
@@ -189,6 +193,155 @@ router.post('/push-tokens/subscriptions', async (req, res) => {
   } catch (err) {
     pushLogger.error({ err, userSub }, 'Failed to save subscriptions');
     res.status(500).json({ error: 'Failed to save subscriptions' });
+  }
+});
+
+// --- Test push notification endpoints ---
+
+router.get('/push-test/tokens', async (req, res) => {
+  const userSub = req.user?.sub;
+  if (!userSub) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  try {
+    const [apnsTokens, deviceTokens] = await Promise.all([
+      getApnsTokensByUser(userSub),
+      getDeviceTokensByUser(userSub),
+    ]);
+    res.json({
+      alert: apnsTokens.map((t) => ({
+        deviceName: t.deviceName,
+        bundleId: t.bundleId,
+        token: `${t.token.substring(0, 8)}...`,
+      })),
+      pushToStart: deviceTokens.map((t) => ({
+        deviceName: t.deviceName,
+        bundleId: t.bundleId,
+        token: `${t.pushToStartToken.substring(0, 8)}...`,
+      })),
+    });
+  } catch (err) {
+    pushLogger.error({ err }, 'Failed to list test tokens');
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+router.post('/push-test/alert', async (req, res) => {
+  const userSub = req.user?.sub;
+  if (!userSub) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const { title, body, bundleId } = req.body as {
+    title?: string; body?: string; bundleId?: string;
+  };
+
+  try {
+    const tokens = await getApnsTokensByUser(userSub);
+    const filtered = bundleId
+      ? tokens.filter((t) => t.bundleId === bundleId)
+      : tokens;
+
+    if (filtered.length === 0) {
+      res.status(404).json({ error: 'No alert tokens found' });
+      return;
+    }
+
+    const results = await Promise.allSettled(
+      filtered.map((t) => sendAlertNotification(
+        t.token,
+        title || 'Test Notification',
+        body || 'This is a test push from FluxHaus Server',
+      )),
+    );
+
+    const sent = results.filter((r) => r.status === 'fulfilled' && r.value).length;
+    pushLogger.info({ userSub, sent, total: filtered.length }, 'Test alert sent');
+    res.json({ sent, total: filtered.length });
+  } catch (err) {
+    pushLogger.error({ err }, 'Test alert failed');
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+router.post('/push-test/push-to-start', async (req, res) => {
+  const userSub = req.user?.sub;
+  if (!userSub) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const { app, bundleId } = req.body as { app?: string; bundleId?: string };
+  const isGT3 = app === 'gt3' || bundleId === 'org.davidjensenius.GT3Companion';
+
+  try {
+    const tokens = await getDeviceTokensByUser(userSub);
+    const targetBundle = isGT3
+      ? 'org.davidjensenius.GT3Companion'
+      : (bundleId || 'org.davidjensenius.FluxHaus');
+    const filtered = tokens.filter((t) => t.bundleId === targetBundle);
+
+    if (filtered.length === 0) {
+      res.status(404).json({
+        error: `No push-to-start tokens found for ${targetBundle}`,
+        available: [...new Set(tokens.map((t) => t.bundleId))],
+      });
+      return;
+    }
+
+    let results;
+    if (isGT3) {
+      const contentState = {
+        speed: 0,
+        battery: 85,
+        tripDistance: 0,
+        estimatedRange: 42.0,
+        gearMode: 2,
+        bmsTemp: 25.0,
+        isCharging: false,
+        isAwake: true,
+        isConnected: true,
+      };
+      results = await Promise.allSettled(
+        filtered.map((t) => sendGT3PushToStart(t.pushToStartToken, contentState)),
+      );
+    } else {
+      const contentState = {
+        device: {
+          name: 'Test Device',
+          progress: 0.5,
+          icon: 'washer',
+          trailingText: 'Test push-to-start',
+          shortText: '30 min',
+          running: true,
+        },
+      };
+      results = await Promise.allSettled(
+        filtered.map((t) => sendPushToStart(t.pushToStartToken, contentState)),
+      );
+    }
+
+    const sent = results.filter((r) => r.status === 'fulfilled' && r.value).length;
+    pushLogger.info(
+      {
+        userSub,
+        app: isGT3 ? 'GT3' : 'FluxHaus',
+        sent,
+        total: filtered.length,
+      },
+      'Test push-to-start sent',
+    );
+    res.json({
+      app: isGT3 ? 'GT3' : 'FluxHaus',
+      sent,
+      total: filtered.length,
+    });
+  } catch (err) {
+    pushLogger.error({ err }, 'Test push-to-start failed');
+    res.status(500).json({ error: 'Internal server error' });
   }
 });
 


### PR DESCRIPTION
This pull request adds new functionality for managing and sending push-to-start notifications, especially for the GT3 Companion app, and introduces new endpoints for testing push notifications. It also enhances token management with new query utilities. The most important changes are grouped below:

**GT3 Companion Push-to-Start Support:**

* Added a new function `sendGT3PushToStart` in `src/apns.ts` to send push-to-start notifications specifically for the GT3 Companion app, using the appropriate bundle ID and notification payload.
* Introduced a new route `POST /gt3/activity/start` in `src/routes/gt3.routes.ts` to trigger GT3 push-to-start notifications for all registered tokens of a user.

**Push Notification Testing Endpoints:**

* Added new endpoints in `src/routes/push.routes.ts` for testing push notifications:
  - `GET /push-test/tokens`: Lists APNs and push-to-start tokens for the authenticated user.
  - `POST /push-test/alert`: Sends a test alert notification to all or filtered APNs tokens.
  - [`POST /push-test/push-to-start`](diffhunk://#diff-9ef53109f6209d3a3b6f380c5d8691a1940f36a1e02f0f683a7013c6c0ec79b2R199-R347): Sends a test push-to-start notification, supporting both GT3 and FluxHaus apps.

**Token Query and Management Utilities:**

* Added utility functions in `src/push-token-store.ts` to fetch device tokens and APNs tokens by user and/or bundle ID, enabling more granular token management. [[1]](diffhunk://#diff-6be7c77a631b2a05994560f4b9873e0e3b3330890b9a0eaf49204971e9096b49R139-R161) [[2]](diffhunk://#diff-6be7c77a631b2a05994560f4b9873e0e3b3330890b9a0eaf49204971e9096b49R234-R270)

**Imports and Internal Wiring:**

* Updated imports in `src/routes/gt3.routes.ts` and `src/routes/push.routes.ts` to use the new GT3 push and token query utilities. [[1]](diffhunk://#diff-d7a79589c3f6f9e96b3379ee16f6d2971034347a4eddd2864aa13a5388747933R6-R7) [[2]](diffhunk://#diff-9ef53109f6209d3a3b6f380c5d8691a1940f36a1e02f0f683a7013c6c0ec79b2L3-R11)