### PR TITLE
chore: release 2.1.54

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fluxhaus-server",
-  "version": "2.1.53",
+  "version": "2.1.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fluxhaus-server",
-      "version": "2.1.53",
+      "version": "2.1.54",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxhaus-server",
-  "version": "2.1.53",
+  "version": "2.1.54",
   "description": "",
   "main": "index.js",
   "type": "commonjs",


### PR DESCRIPTION
This PR bumps the version to 2.1.54.