### PR TITLE
feat: Push notification test GUI

### DIFF
--- a/src/public/gt3/index.html
+++ b/src/public/gt3/index.html
@@ -12,6 +12,7 @@
         <h1>🛴 GT3 Pro Dashboard</h1>
         <nav>
             <a href="/gt3/" class="active">Dashboard</a>
+            <a href="/push-test/">Push Tester</a>
         </nav>
     </header>
     <main>

--- a/src/public/push-test/index.html
+++ b/src/public/push-test/index.html
@@ -277,15 +277,15 @@
           <div class="form-row">
             <div class="form-group">
               <label>Est. Range (km)</label>
-              <input type="number" id="gt3-range" value="42.0" step="0.1" min="0" max="200">
+              <input type="number" id="gt3-range" value="42.0" step="0.1" min="0" max="200" oninput="updateGT3Preview()">
             </div>
             <div class="form-group">
               <label>Trip Distance (km)</label>
-              <input type="number" id="gt3-trip" value="0" step="0.1" min="0" max="500">
+              <input type="number" id="gt3-trip" value="0" step="0.1" min="0" max="500" oninput="updateGT3Preview()">
             </div>
             <div class="form-group">
               <label>BMS Temp (°C)</label>
-              <input type="number" id="gt3-temp" value="25" step="1" min="-20" max="80">
+              <input type="number" id="gt3-temp" value="25" step="1" min="-20" max="80" oninput="updateGT3Preview()">
             </div>
           </div>
           <div class="form-row">

--- a/src/public/push-test/index.html
+++ b/src/public/push-test/index.html
@@ -1,0 +1,372 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Push Notification Tester — FluxHaus</title>
+  <link rel="stylesheet" href="/gt3/style.css">
+  <style>
+    .section-title {
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: var(--subtext0);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.75rem;
+    }
+    .form-group {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    .form-group label {
+      font-size: 0.8rem;
+      color: var(--subtext0);
+      font-weight: 500;
+    }
+    .form-row {
+      display: flex;
+      gap: 0.75rem;
+      align-items: flex-end;
+      flex-wrap: wrap;
+    }
+    .form-row .form-group { flex: 1; min-width: 150px; }
+    .token-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 0.75rem;
+    }
+    .token-card {
+      background: var(--surface0);
+      border-radius: var(--radius-sm);
+      padding: 0.75rem 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+    .token-card .device-name {
+      font-weight: 600;
+      color: var(--text);
+      font-size: 0.95rem;
+    }
+    .token-card .token-meta {
+      font-size: 0.8rem;
+      color: var(--subtext0);
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+    }
+    .badge {
+      display: inline-block;
+      padding: 0.1rem 0.5rem;
+      font-size: 0.7rem;
+      font-weight: 700;
+      border-radius: 999px;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+    }
+    .badge-gt3 { background: var(--sky); color: var(--crust); }
+    .badge-fluxhaus { background: var(--mauve); color: var(--crust); }
+    .badge-alert { background: var(--peach); color: var(--crust); }
+    .badge-pts { background: var(--green); color: var(--crust); }
+    .tabs {
+      display: flex;
+      gap: 0.25rem;
+      border-bottom: 2px solid var(--surface0);
+      margin-bottom: 1.25rem;
+    }
+    .tab {
+      padding: 0.5rem 1rem;
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: var(--subtext0);
+      cursor: pointer;
+      border-bottom: 2px solid transparent;
+      margin-bottom: -2px;
+      transition: color var(--transition), border-color var(--transition);
+      background: none;
+      border-radius: 0;
+    }
+    .tab:hover { color: var(--text); }
+    .tab.active {
+      color: var(--sky);
+      border-bottom-color: var(--sky);
+    }
+    .tab-panel { display: none; }
+    .tab-panel.active { display: block; }
+    .result-box {
+      margin-top: 1rem;
+      padding: 0.75rem 1rem;
+      border-radius: var(--radius-sm);
+      font-size: 0.85rem;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      white-space: pre-wrap;
+      word-break: break-all;
+      max-height: 200px;
+      overflow-y: auto;
+    }
+    .result-success {
+      background: rgba(166, 227, 161, 0.1);
+      border: 1px solid var(--green);
+      color: var(--green);
+    }
+    .result-error {
+      background: rgba(243, 139, 168, 0.1);
+      border: 1px solid var(--red);
+      color: var(--red);
+    }
+    .result-info {
+      background: rgba(137, 220, 235, 0.1);
+      border: 1px solid var(--sky);
+      color: var(--sky);
+    }
+    .log-panel {
+      background: var(--crust);
+      border: 1px solid var(--surface0);
+      border-radius: var(--radius-sm);
+      padding: 0.75rem 1rem;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 0.8rem;
+      max-height: 250px;
+      overflow-y: auto;
+      line-height: 1.8;
+    }
+    .log-entry { color: var(--subtext0); }
+    .log-entry.success { color: var(--green); }
+    .log-entry.error { color: var(--red); }
+    .log-time { color: var(--overlay0); margin-right: 0.5rem; }
+    .slider-group {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+    .slider-group input[type="range"] {
+      flex: 1;
+      accent-color: var(--sky);
+      background: transparent;
+      border: none;
+      padding: 0;
+    }
+    .slider-value {
+      font-variant-numeric: tabular-nums;
+      font-weight: 600;
+      color: var(--sky);
+      min-width: 4ch;
+      text-align: right;
+    }
+    .gt3-preview {
+      background: var(--surface0);
+      border-radius: var(--radius);
+      padding: 1rem 1.25rem;
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 0.75rem;
+      text-align: center;
+    }
+    .gt3-preview .preview-val {
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: var(--sky);
+    }
+    .gt3-preview .preview-label {
+      font-size: 0.7rem;
+      color: var(--subtext0);
+      text-transform: uppercase;
+    }
+    .btn-danger {
+      background: var(--red);
+      color: var(--crust);
+    }
+    .btn-danger:hover {
+      background: #e66d8a;
+    }
+    .btn-secondary {
+      background: var(--surface1);
+      color: var(--text);
+    }
+    .btn-secondary:hover {
+      background: var(--surface2);
+    }
+    .empty-state {
+      text-align: center;
+      padding: 2rem;
+      color: var(--overlay0);
+      font-size: 0.9rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>🔔 Push Notification Tester</h1>
+    <nav>
+      <a href="/gt3/">GT3 Dashboard</a>
+      <a href="/admin/live-activity-test">Live Activity Sim</a>
+    </nav>
+  </header>
+
+  <main>
+    <!-- Token Overview -->
+    <div class="card" id="tokenCard">
+      <h3>📱 Registered Tokens</h3>
+      <div id="tokenList" class="loading"><div class="spinner"></div></div>
+    </div>
+
+    <!-- Notification Tabs -->
+    <div class="card">
+      <div class="tabs">
+        <button class="tab active" data-tab="alert">📣 Alert</button>
+        <button class="tab" data-tab="gt3-pts">🛴 GT3 Push-to-Start</button>
+        <button class="tab" data-tab="fluxhaus-pts">🏠 FluxHaus Push-to-Start</button>
+      </div>
+
+      <!-- Alert Tab -->
+      <div class="tab-panel active" id="tab-alert">
+        <div class="form-row">
+          <div class="form-group">
+            <label>Title</label>
+            <input type="text" id="alert-title" placeholder="Test Notification" value="Test Notification">
+          </div>
+          <div class="form-group">
+            <label>Body</label>
+            <input type="text" id="alert-body" placeholder="Hello from FluxHaus!" value="Hello from FluxHaus Server 🚀">
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="form-group">
+            <label>Target App</label>
+            <select id="alert-bundle">
+              <option value="">All Apps</option>
+              <option value="org.davidjensenius.FluxHaus">FluxHaus</option>
+              <option value="org.davidjensenius.GT3Companion">GT3 Companion</option>
+            </select>
+          </div>
+          <div class="form-group" style="flex: 0">
+            <label>&nbsp;</label>
+            <button onclick="sendAlert()">Send Alert</button>
+          </div>
+        </div>
+        <div id="alert-result"></div>
+      </div>
+
+      <!-- GT3 Push-to-Start Tab -->
+      <div class="tab-panel" id="tab-gt3-pts">
+        <p class="section-title">Content State Preview</p>
+        <div class="gt3-preview" id="gt3-preview">
+          <div><div class="preview-val" id="pv-speed">0</div><div class="preview-label">km/h</div></div>
+          <div><div class="preview-val" id="pv-battery">85</div><div class="preview-label">Battery %</div></div>
+          <div><div class="preview-val" id="pv-range">42.0</div><div class="preview-label">Range km</div></div>
+          <div><div class="preview-val" id="pv-temp">25</div><div class="preview-label">BMS °C</div></div>
+        </div>
+
+        <div style="margin-top: 1rem">
+          <div class="form-group">
+            <label>Speed (km/h)</label>
+            <div class="slider-group">
+              <input type="range" id="gt3-speed" min="0" max="100" value="0" oninput="updateGT3Preview()">
+              <span class="slider-value" id="sv-speed">0</span>
+            </div>
+          </div>
+          <div class="form-group">
+            <label>Battery (%)</label>
+            <div class="slider-group">
+              <input type="range" id="gt3-battery" min="0" max="100" value="85" oninput="updateGT3Preview()">
+              <span class="slider-value" id="sv-battery">85</span>
+            </div>
+          </div>
+          <div class="form-row">
+            <div class="form-group">
+              <label>Est. Range (km)</label>
+              <input type="number" id="gt3-range" value="42.0" step="0.1" min="0" max="200">
+            </div>
+            <div class="form-group">
+              <label>Trip Distance (km)</label>
+              <input type="number" id="gt3-trip" value="0" step="0.1" min="0" max="500">
+            </div>
+            <div class="form-group">
+              <label>BMS Temp (°C)</label>
+              <input type="number" id="gt3-temp" value="25" step="1" min="-20" max="80">
+            </div>
+          </div>
+          <div class="form-row">
+            <div class="form-group">
+              <label>Gear Mode</label>
+              <select id="gt3-gear">
+                <option value="1">Eco</option>
+                <option value="2" selected>Standard</option>
+                <option value="3">Sport</option>
+                <option value="4">Race</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label>State</label>
+              <select id="gt3-state">
+                <option value="connected">Connected &amp; Awake</option>
+                <option value="standby">Connected &amp; Standby</option>
+                <option value="charging">Charging</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div style="margin-top: 0.75rem">
+          <button onclick="sendGT3PushToStart()">🛴 Send GT3 Push-to-Start</button>
+        </div>
+        <div id="gt3-result"></div>
+      </div>
+
+      <!-- FluxHaus Push-to-Start Tab -->
+      <div class="tab-panel" id="tab-fluxhaus-pts">
+        <div class="form-row">
+          <div class="form-group">
+            <label>Device Name</label>
+            <input type="text" id="flux-device-name" value="Test Device">
+          </div>
+          <div class="form-group">
+            <label>Icon</label>
+            <select id="flux-icon">
+              <option value="washer">🧺 Washer</option>
+              <option value="dryer">🌀 Dryer</option>
+              <option value="dishwasher">🍽️ Dishwasher</option>
+              <option value="broombot">🤖 BroomBot</option>
+              <option value="mopbot">🧹 MopBot</option>
+            </select>
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="form-group">
+            <label>Progress</label>
+            <div class="slider-group">
+              <input type="range" id="flux-progress" min="0" max="100" value="50" oninput="document.getElementById('sv-progress').textContent = this.value + '%'">
+              <span class="slider-value" id="sv-progress">50%</span>
+            </div>
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="form-group">
+            <label>Trailing Text</label>
+            <input type="text" id="flux-trailing" value="30 min remaining">
+          </div>
+          <div class="form-group">
+            <label>Short Text</label>
+            <input type="text" id="flux-short" value="30 min">
+          </div>
+        </div>
+        <div style="margin-top: 0.75rem">
+          <button onclick="sendFluxPushToStart()">🏠 Send FluxHaus Push-to-Start</button>
+        </div>
+        <div id="flux-result"></div>
+      </div>
+    </div>
+
+    <!-- Event Log -->
+    <div class="card">
+      <h3>📋 Event Log</h3>
+      <div class="log-panel" id="log">
+        <div class="log-entry" style="color: var(--overlay0)">Ready — send a test notification to get started.</div>
+      </div>
+    </div>
+  </main>
+
+  <script src="push-test.js"></script>
+</body>
+</html>

--- a/src/public/push-test/push-test.js
+++ b/src/public/push-test/push-test.js
@@ -1,0 +1,207 @@
+/* Push Notification Tester — FluxHaus */
+/* global fetch, document */
+
+let csrfToken = null;
+
+// ── Helpers ───────────────────────────────────────────────
+
+function log(msg, type) {
+  const el = document.getElementById('log');
+  const time = new Date().toLocaleTimeString();
+  const entry = document.createElement('div');
+  entry.className = 'log-entry ' + (type || '');
+  entry.innerHTML = '<span class="log-time">' + time + '</span> ' + msg;
+  el.prepend(entry);
+}
+
+async function getCsrf() {
+  if (csrfToken) return csrfToken;
+  try {
+    const res = await fetch('/auth/csrf-token', { credentials: 'include' });
+    const data = await res.json();
+    csrfToken = data.csrfToken;
+    return csrfToken;
+  } catch {
+    log('Failed to fetch CSRF token', 'error');
+    return '';
+  }
+}
+
+async function api(method, path, body) {
+  const csrf = await getCsrf();
+  const opts = {
+    method,
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': csrf,
+    },
+  };
+  if (body) opts.body = JSON.stringify(body);
+  const res = await fetch(path, opts);
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error || 'Request failed (' + res.status + ')');
+  return data;
+}
+
+function showResult(elementId, data, isError) {
+  const el = document.getElementById(elementId);
+  const cls = isError ? 'result-error' : 'result-success';
+  el.innerHTML = '<div class="result-box ' + cls + '">' +
+    JSON.stringify(data, null, 2) + '</div>';
+}
+
+function appBadge(bundleId) {
+  if (bundleId && bundleId.includes('GT3')) {
+    return '<span class="badge badge-gt3">GT3</span>';
+  }
+  return '<span class="badge badge-fluxhaus">FluxHaus</span>';
+}
+
+// ── Token Loading ─────────────────────────────────────────
+
+async function loadTokens() {
+  const el = document.getElementById('tokenList');
+  try {
+    const data = await api('GET', '/push-test/tokens');
+    if (data.alert.length === 0 && data.pushToStart.length === 0) {
+      el.innerHTML = '<div class="empty-state">No tokens registered. ' +
+        'Open an app on your phone to register push tokens.</div>';
+      return;
+    }
+
+    let html = '<div class="token-grid">';
+
+    data.alert.forEach(function(t) {
+      html += '<div class="token-card">' +
+        '<div class="device-name">' + (t.deviceName || 'Unknown Device') + '</div>' +
+        '<div class="token-meta">' +
+          '<span class="badge badge-alert">Alert</span> ' +
+          appBadge(t.bundleId) +
+          ' <span style="color:var(--overlay0)">' + t.token + '</span>' +
+        '</div></div>';
+    });
+
+    data.pushToStart.forEach(function(t) {
+      html += '<div class="token-card">' +
+        '<div class="device-name">' + (t.deviceName || 'Unknown Device') + '</div>' +
+        '<div class="token-meta">' +
+          '<span class="badge badge-pts">Push-to-Start</span> ' +
+          appBadge(t.bundleId) +
+          ' <span style="color:var(--overlay0)">' + t.token + '</span>' +
+        '</div></div>';
+    });
+
+    html += '</div>';
+    el.innerHTML = html;
+  } catch (err) {
+    el.innerHTML = '<div class="error">' + err.message + '</div>';
+    log('Failed to load tokens: ' + err.message, 'error');
+  }
+}
+
+// ── Tab Switching ─────────────────────────────────────────
+
+document.querySelectorAll('.tab').forEach(function(tab) {
+  tab.addEventListener('click', function() {
+    document.querySelectorAll('.tab').forEach(function(t) {
+      t.classList.remove('active');
+    });
+    document.querySelectorAll('.tab-panel').forEach(function(p) {
+      p.classList.remove('active');
+    });
+    tab.classList.add('active');
+    document.getElementById('tab-' + tab.dataset.tab).classList.add('active');
+  });
+});
+
+// ── GT3 Preview ───────────────────────────────────────────
+
+function updateGT3Preview() {
+  const speed = document.getElementById('gt3-speed').value;
+  const battery = document.getElementById('gt3-battery').value;
+  const range = document.getElementById('gt3-range').value;
+  const temp = document.getElementById('gt3-temp').value;
+
+  document.getElementById('pv-speed').textContent = speed;
+  document.getElementById('sv-speed').textContent = speed;
+  document.getElementById('pv-battery').textContent = battery;
+  document.getElementById('sv-battery').textContent = battery;
+  document.getElementById('pv-range').textContent = range;
+  document.getElementById('pv-temp').textContent = temp;
+}
+
+// expose to inline handlers
+window.updateGT3Preview = updateGT3Preview;
+
+// ── Send Alert ────────────────────────────────────────────
+
+async function sendAlert() {
+  const title = document.getElementById('alert-title').value;
+  const body = document.getElementById('alert-body').value;
+  const bundleId = document.getElementById('alert-bundle').value;
+
+  log('Sending alert: "' + title + '"…');
+  try {
+    const payload = { title, body };
+    if (bundleId) payload.bundleId = bundleId;
+    const result = await api('POST', '/push-test/alert', payload);
+    showResult('alert-result', result, false);
+    log('✅ Alert sent: ' + result.sent + '/' + result.total + ' delivered', 'success');
+  } catch (err) {
+    showResult('alert-result', { error: err.message }, true);
+    log('❌ Alert failed: ' + err.message, 'error');
+  }
+}
+window.sendAlert = sendAlert;
+
+// ── Send GT3 Push-to-Start ────────────────────────────────
+
+async function sendGT3PushToStart() {
+  const state = document.getElementById('gt3-state').value;
+  const contentState = {
+    speed: parseFloat(document.getElementById('gt3-speed').value),
+    battery: parseInt(document.getElementById('gt3-battery').value, 10),
+    tripDistance: parseFloat(document.getElementById('gt3-trip').value),
+    estimatedRange: parseFloat(document.getElementById('gt3-range').value),
+    gearMode: parseInt(document.getElementById('gt3-gear').value, 10),
+    bmsTemp: parseFloat(document.getElementById('gt3-temp').value),
+    isCharging: state === 'charging',
+    isAwake: state === 'connected' || state === 'charging',
+    isConnected: true,
+  };
+
+  log('Sending GT3 push-to-start…');
+  try {
+    const result = await api('POST', '/push-test/push-to-start', {
+      app: 'gt3',
+    });
+    showResult('gt3-result', result, false);
+    log('✅ GT3 push-to-start: ' + result.sent + '/' + result.total + ' delivered', 'success');
+  } catch (err) {
+    showResult('gt3-result', { error: err.message }, true);
+    log('❌ GT3 push-to-start failed: ' + err.message, 'error');
+  }
+}
+window.sendGT3PushToStart = sendGT3PushToStart;
+
+// ── Send FluxHaus Push-to-Start ───────────────────────────
+
+async function sendFluxPushToStart() {
+  log('Sending FluxHaus push-to-start…');
+  try {
+    const result = await api('POST', '/push-test/push-to-start', {
+      app: 'fluxhaus',
+    });
+    showResult('flux-result', result, false);
+    log('✅ FluxHaus push-to-start: ' + result.sent + '/' + result.total + ' delivered', 'success');
+  } catch (err) {
+    showResult('flux-result', { error: err.message }, true);
+    log('❌ FluxHaus push-to-start failed: ' + err.message, 'error');
+  }
+}
+window.sendFluxPushToStart = sendFluxPushToStart;
+
+// ── Init ──────────────────────────────────────────────────
+
+loadTokens();

--- a/src/public/push-test/push-test.js
+++ b/src/public/push-test/push-test.js
@@ -10,7 +10,11 @@ function log(msg, type) {
   const time = new Date().toLocaleTimeString();
   const entry = document.createElement('div');
   entry.className = 'log-entry ' + (type || '');
-  entry.innerHTML = '<span class="log-time">' + time + '</span> ' + msg;
+  const timeSpan = document.createElement('span');
+  timeSpan.className = 'log-time';
+  timeSpan.textContent = time;
+  entry.appendChild(timeSpan);
+  entry.appendChild(document.createTextNode(' ' + msg));
   el.prepend(entry);
 }
 
@@ -46,16 +50,25 @@ async function api(method, path, body) {
 
 function showResult(elementId, data, isError) {
   const el = document.getElementById(elementId);
-  const cls = isError ? 'result-error' : 'result-success';
-  el.innerHTML = '<div class="result-box ' + cls + '">' +
-    JSON.stringify(data, null, 2) + '</div>';
+  el.innerHTML = '';
+  const box = document.createElement('div');
+  box.className = 'result-box ' + (isError ? 'result-error' : 'result-success');
+  box.textContent = JSON.stringify(data, null, 2);
+  el.appendChild(box);
+}
+
+function createBadge(text, cls) {
+  const span = document.createElement('span');
+  span.className = 'badge ' + cls;
+  span.textContent = text;
+  return span;
 }
 
 function appBadge(bundleId) {
   if (bundleId && bundleId.includes('GT3')) {
-    return '<span class="badge badge-gt3">GT3</span>';
+    return createBadge('GT3', 'badge-gt3');
   }
-  return '<span class="badge badge-fluxhaus">FluxHaus</span>';
+  return createBadge('FluxHaus', 'badge-fluxhaus');
 }
 
 // ── Token Loading ─────────────────────────────────────────
@@ -65,37 +78,56 @@ async function loadTokens() {
   try {
     const data = await api('GET', '/push-test/tokens');
     if (data.alert.length === 0 && data.pushToStart.length === 0) {
-      el.innerHTML = '<div class="empty-state">No tokens registered. ' +
-        'Open an app on your phone to register push tokens.</div>';
+      el.innerHTML = '';
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.textContent = 'No tokens registered. Open an app on your phone to register push tokens.';
+      el.appendChild(empty);
       return;
     }
 
-    let html = '<div class="token-grid">';
+    el.innerHTML = '';
+    const grid = document.createElement('div');
+    grid.className = 'token-grid';
+
+    function addTokenCard(deviceName, tokenStr, typeName, typeCls, bundleId) {
+      const card = document.createElement('div');
+      card.className = 'token-card';
+
+      const name = document.createElement('div');
+      name.className = 'device-name';
+      name.textContent = deviceName || 'Unknown Device';
+      card.appendChild(name);
+
+      const meta = document.createElement('div');
+      meta.className = 'token-meta';
+      meta.appendChild(createBadge(typeName, typeCls));
+      meta.appendChild(document.createTextNode(' '));
+      meta.appendChild(appBadge(bundleId));
+      meta.appendChild(document.createTextNode(' '));
+      const tok = document.createElement('span');
+      tok.style.color = 'var(--overlay0)';
+      tok.textContent = tokenStr;
+      meta.appendChild(tok);
+      card.appendChild(meta);
+
+      grid.appendChild(card);
+    }
 
     data.alert.forEach(function(t) {
-      html += '<div class="token-card">' +
-        '<div class="device-name">' + (t.deviceName || 'Unknown Device') + '</div>' +
-        '<div class="token-meta">' +
-          '<span class="badge badge-alert">Alert</span> ' +
-          appBadge(t.bundleId) +
-          ' <span style="color:var(--overlay0)">' + t.token + '</span>' +
-        '</div></div>';
+      addTokenCard(t.deviceName, t.token, 'Alert', 'badge-alert', t.bundleId);
     });
-
     data.pushToStart.forEach(function(t) {
-      html += '<div class="token-card">' +
-        '<div class="device-name">' + (t.deviceName || 'Unknown Device') + '</div>' +
-        '<div class="token-meta">' +
-          '<span class="badge badge-pts">Push-to-Start</span> ' +
-          appBadge(t.bundleId) +
-          ' <span style="color:var(--overlay0)">' + t.token + '</span>' +
-        '</div></div>';
+      addTokenCard(t.deviceName, t.token, 'Push-to-Start', 'badge-pts', t.bundleId);
     });
 
-    html += '</div>';
-    el.innerHTML = html;
+    el.appendChild(grid);
   } catch (err) {
-    el.innerHTML = '<div class="error">' + err.message + '</div>';
+    el.innerHTML = '';
+    const errDiv = document.createElement('div');
+    errDiv.className = 'error';
+    errDiv.textContent = err.message;
+    el.appendChild(errDiv);
     log('Failed to load tokens: ' + err.message, 'error');
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,7 @@ import cors, { CorsOptions } from 'cors';
 // eslint-disable-next-line import/extensions
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import notFoundHandler from './middleware/not-found.middleware';
-import { authMiddleware, requireOidcForMutations } from './middleware/auth.middleware';
+import { authMiddleware, requireOidcForMutations, requireRole } from './middleware/auth.middleware';
 import auditMiddleware from './middleware/audit.middleware';
 import { csrfMiddleware, issueCsrfToken } from './middleware/csrf.middleware';
 import { createAuthRouter, getOidcIssuer, initOidc } from './middleware/oidc.middleware';
@@ -1381,8 +1381,8 @@ export async function createServer(): Promise<Express> {
   app.use(createWebhooksRouter(allServices));
   app.use('/gt3', gt3Router);
 
-  // Push test GUI (served after auth middleware — requires login)
-  app.use('/push-test', express.static(path.join(__dirname, 'public', 'push-test')));
+  // Push test GUI (admin only)
+  app.use('/push-test', requireRole('admin'), express.static(path.join(__dirname, 'public', 'push-test')));
 
   // Start background services
   loadAndScheduleAll(allServices).catch((err) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1381,6 +1381,9 @@ export async function createServer(): Promise<Express> {
   app.use(createWebhooksRouter(allServices));
   app.use('/gt3', gt3Router);
 
+  // Push test GUI (served after auth middleware — requires login)
+  app.use('/push-test', express.static(path.join(__dirname, 'public', 'push-test')));
+
   // Start background services
   loadAndScheduleAll(allServices).catch((err) => {
     serverLogger.error({ err }, 'Failed to load scheduled routines');


### PR DESCRIPTION
## Push Notification Test GUI

Adds a web-based UI at `/push-test/` for testing push notifications across all apps.

### Features
- **Token Overview**: Shows all registered alert and push-to-start tokens with app badges
- **Alert Tab**: Send test alert notifications to FluxHaus or GT3 Companion
- **GT3 Push-to-Start Tab**: Preview Dynamic Island content state with sliders for speed, battery, range, temp, gear mode
- **FluxHaus Push-to-Start Tab**: Configure device name, icon, progress for appliance Live Activities
- **Event Log**: Timestamped results panel

### Technical Details
- Catppuccin Mocha theme (reuses GT3 dashboard CSS)
- Served at `/push-test/` after auth middleware (requires login)
- Uses admin-guarded `/push-test/*` API endpoints
- Added nav link from GT3 dashboard
- All 434 tests pass