### PR TITLE
fix: Swift-compatible Date encoding for GT3 push-to-start

### DIFF
--- a/src/apns.ts
+++ b/src/apns.ts
@@ -228,7 +228,7 @@ export async function sendGT3PushToStart(
       'attributes-type': 'GT3RideAttributes',
       attributes: {
         scooterName: 'GT3 Pro',
-        startTime: new Date().toISOString(),
+        startTime: (Date.now() / 1000) - 978307200,
       },
       alert: {
         title: 'GT3 Pro Connected',

--- a/src/apns.ts
+++ b/src/apns.ts
@@ -16,6 +16,10 @@ let provider: apn.Provider | null = null;
 const lastPushTimestamps = new Map<string, number>();
 const THROTTLE_INTERVAL_MS = 15_000;
 
+// Seconds between Unix epoch (1970) and Apple/Swift reference date (Jan 1, 2001).
+// Swift's default Date Codable encoding uses timeIntervalSinceReferenceDate.
+const APPLE_REFERENCE_DATE_OFFSET = 978_307_200;
+
 export function initApns(): void {
   const {
     APNS_KEY_PATH, APNS_KEY_ID, APNS_TEAM_ID, APNS_ENVIRONMENT,
@@ -228,7 +232,7 @@ export async function sendGT3PushToStart(
       'attributes-type': 'GT3RideAttributes',
       attributes: {
         scooterName: 'GT3 Pro',
-        startTime: (Date.now() / 1000) - 978307200,
+        startTime: (Date.now() / 1000) - APPLE_REFERENCE_DATE_OFFSET,
       },
       alert: {
         title: 'GT3 Pro Connected',


### PR DESCRIPTION
The `startTime` attribute in `GT3RideAttributes` is a Swift `Date`, which Codable encodes as `timeIntervalSinceReferenceDate` (seconds since Jan 1, 2001) by default. The server was sending an ISO 8601 string, causing silent decode failure on iOS — APNs accepted the push but the device never created the Live Activity.

Fixed by sending `(Date.now() / 1000) - 978307200` (Unix epoch → Apple reference date).

This explains why GT3 push-to-start showed `sent=1, failed=0` in server logs but never appeared on the device.