### PR TITLE
fix: Upgrade auth failure logging for GT3 401 debugging

### DIFF
--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -154,6 +154,17 @@ export async function authMiddleware(
   }
 
   // 5. No valid auth (API clients get 401)
+  const hasBearerToken = authHeader.startsWith('Bearer ');
+  authLogger.warn(
+    {
+      route: req.path,
+      method: req.method,
+      reason: hasBearerToken ? 'token_rejected' : (authHeader ? 'invalid_credentials' : 'no_credentials'),
+      hasBearer: hasBearerToken,
+      tokenPreview: hasBearerToken ? `${authHeader.slice(7, 17)}…` : undefined,
+    },
+    'Auth failed — returning 401',
+  );
   logEvent({
     role: 'anonymous',
     action: 'auth_failed',

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -155,11 +155,17 @@ export async function authMiddleware(
 
   // 5. No valid auth (API clients get 401)
   const hasBearerToken = authHeader.startsWith('Bearer ');
+  let reason = 'no_credentials';
+  if (hasBearerToken) {
+    reason = 'token_rejected';
+  } else if (authHeader) {
+    reason = 'invalid_credentials';
+  }
   authLogger.warn(
     {
       route: req.path,
       method: req.method,
-      reason: hasBearerToken ? 'token_rejected' : (authHeader ? 'invalid_credentials' : 'no_credentials'),
+      reason,
       hasBearer: hasBearerToken,
       tokenPreview: hasBearerToken ? `${authHeader.slice(7, 17)}…` : undefined,
     },

--- a/src/middleware/oidc.middleware.ts
+++ b/src/middleware/oidc.middleware.ts
@@ -73,7 +73,8 @@ export async function validateBearerToken(
         preferred_username: jwtPayload.preferred_username,
       };
     } catch (err) {
-      oidcLogger.debug({ err }, 'JWT validation failed, trying userinfo fallback');
+      const jwtErr = err as Error;
+      oidcLogger.warn({ err: jwtErr.message, route: 'validateBearerToken' }, 'JWT validation failed, trying userinfo fallback');
     }
   }
 
@@ -88,7 +89,8 @@ export async function validateBearerToken(
         preferred_username: userinfo.preferred_username as string | undefined,
       };
     } catch (err) {
-      oidcLogger.debug({ err }, 'Bearer token validation failed');
+      const uiErr = err as Error;
+      oidcLogger.warn({ err: uiErr.message }, 'Bearer token userinfo validation also failed');
       return null;
     }
   }

--- a/src/middleware/oidc.middleware.ts
+++ b/src/middleware/oidc.middleware.ts
@@ -74,7 +74,10 @@ export async function validateBearerToken(
       };
     } catch (err) {
       const jwtErr = err as Error;
-      oidcLogger.warn({ err: jwtErr.message, route: 'validateBearerToken' }, 'JWT validation failed, trying userinfo fallback');
+      oidcLogger.warn(
+        { err: jwtErr.message, route: 'validateBearerToken' },
+        'JWT validation failed, trying userinfo fallback',
+      );
     }
   }
 


### PR DESCRIPTION
JWT validation and auth middleware failures were only logged at debug level, making 401 errors invisible in production logs.

- JWT validation failure → warn with error message
- Userinfo fallback failure → warn with error message
- Auth middleware 401 → logs route, method, token_rejected vs no_credentials

This will show exactly why the GT3 app's Bearer tokens are being rejected during background BLE reconnect.