### PR TITLE
fix: Address Copilot review feedback on auth middleware

### DIFF
--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from 'express';
+import { createHash } from 'crypto';
 import { AuthenticatedUser } from '../types/auth';
 import { isOidcEnabled, validateBearerToken } from './oidc.middleware';
 import { serverOrigin, verifyMcpToken } from '../mcp-auth';
@@ -161,25 +162,29 @@ export async function authMiddleware(
   } else if (authHeader) {
     reason = 'invalid_credentials';
   }
-  authLogger.warn(
-    {
-      route: req.path,
-      method: req.method,
-      reason,
-      hasBearer: hasBearerToken,
-      tokenPreview: hasBearerToken ? `${authHeader.slice(7, 17)}…` : undefined,
-    },
-    'Auth failed — returning 401',
-  );
+  const authFailureLog = {
+    route: req.path,
+    method: req.method,
+    reason,
+    hasBearer: hasBearerToken,
+    tokenHash: hasBearerToken
+      ? createHash('sha256').update(authHeader.slice(7)).digest('hex').slice(0, 12)
+      : undefined,
+  };
+  if (reason === 'token_rejected') {
+    authLogger.warn(authFailureLog, 'Auth failed — returning 401');
+  } else {
+    authLogger.info(authFailureLog, 'Auth failed — returning 401');
+  }
   logEvent({
     role: 'anonymous',
     action: 'auth_failed',
     route: req.path,
     method: req.method,
     ip: req.ip,
-    details: { reason: authHeader ? 'invalid_credentials' : 'no_credentials' },
+    details: { reason },
   }).catch(() => {});
-  writePoint('auth', { count: 1 }, { result: 'failed', reason: authHeader ? 'invalid_credentials' : 'no_credentials' });
+  writePoint('auth', { count: 1 }, { result: 'failed', reason });
 
   // RFC 9728 — include resource_metadata pointer for MCP clients
   const origin = serverOrigin(req);

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -167,7 +167,7 @@ export async function authMiddleware(
     method: req.method,
     reason,
     hasBearer: hasBearerToken,
-    tokenHash: hasBearerToken
+    tokenHashPrefix: hasBearerToken
       ? createHash('sha256').update(authHeader.slice(7)).digest('hex').slice(0, 12)
       : undefined,
   };

--- a/src/middleware/oidc.middleware.ts
+++ b/src/middleware/oidc.middleware.ts
@@ -25,6 +25,9 @@ export async function initOidc(): Promise<void> {
     return;
   }
 
+  // Reset trusted issuers on re-init so config always reflects current env
+  trustedIssuers = [];
+
   try {
     oidcIssuer = await Issuer.discover(issuerUrl);
     oidcClient = new oidcIssuer.Client({
@@ -80,7 +83,11 @@ export async function validateBearerToken(
       ...trustedIssuers,
     ].filter(Boolean) as string[];
 
-    const tryIssuer = async (issuer: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let lastError: any = null;
+    const tryIssuer = async (
+      issuer: string,
+    ): Promise<{ sub: string; email?: string; preferred_username?: string } | null> => {
       try {
         const { payload } = await jwtVerify(token, jwks!, { issuer });
         const jwtPayload = payload as JWTPayload & {
@@ -93,24 +100,23 @@ export async function validateBearerToken(
           email: jwtPayload.email,
           preferred_username: jwtPayload.preferred_username,
         };
-      } catch {
+      } catch (err) {
+        lastError = err instanceof Error ? err : new Error(String(err));
         return null;
       }
     };
 
-    // Try each issuer sequentially (short-circuit on first match)
+    // Try each issuer sequentially, short-circuit on first match
     const results = await allIssuers.reduce(
-      async (accP, issuer) => {
-        const acc = await accP;
-        if (acc) return acc;
-        return tryIssuer(issuer);
-      },
-      Promise.resolve(null as { sub: string; email?: string; preferred_username?: string } | null),
+      async (accP, issuer) => (await accP) ?? tryIssuer(issuer),
+      Promise.resolve(
+        null as { sub: string; email?: string; preferred_username?: string } | null,
+      ),
     );
     if (results) return results;
 
     oidcLogger.warn(
-      { route: 'validateBearerToken', issuers: allIssuers },
+      { stage: 'validateBearerToken', issuers: allIssuers, err: lastError?.message },
       'JWT validation failed for all issuers, trying userinfo fallback',
     );
   }
@@ -126,7 +132,7 @@ export async function validateBearerToken(
         preferred_username: userinfo.preferred_username as string | undefined,
       };
     } catch (err) {
-      const uiErr = err as Error;
+      const uiErr = err instanceof Error ? err : new Error(String(err));
       oidcLogger.warn({ err: uiErr.message }, 'Bearer token userinfo validation also failed');
       return null;
     }

--- a/src/middleware/oidc.middleware.ts
+++ b/src/middleware/oidc.middleware.ts
@@ -20,13 +20,16 @@ export async function initOidc(): Promise<void> {
   const clientSecret = process.env.OIDC_CLIENT_SECRET;
   const redirectUri = process.env.OIDC_REDIRECT_URI;
 
+  // Reset all OIDC state on re-init so config always reflects current env
+  oidcClient = null;
+  oidcIssuer = null;
+  jwks = null;
+  trustedIssuers = [];
+
   if (!issuerUrl || !clientId) {
     oidcLogger.warn('OIDC_ISSUER_URL or OIDC_CLIENT_ID not set — OIDC disabled');
     return;
   }
-
-  // Reset trusted issuers on re-init so config always reflects current env
-  trustedIssuers = [];
 
   try {
     oidcIssuer = await Issuer.discover(issuerUrl);
@@ -83,8 +86,7 @@ export async function validateBearerToken(
       ...trustedIssuers,
     ].filter(Boolean) as string[];
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let lastError: any = null;
+    const errorState = { last: null as Error | null };
     const tryIssuer = async (
       issuer: string,
     ): Promise<{ sub: string; email?: string; preferred_username?: string } | null> => {
@@ -101,7 +103,7 @@ export async function validateBearerToken(
           preferred_username: jwtPayload.preferred_username,
         };
       } catch (err) {
-        lastError = err instanceof Error ? err : new Error(String(err));
+        errorState.last = err instanceof Error ? err : new Error(String(err));
         return null;
       }
     };
@@ -116,7 +118,7 @@ export async function validateBearerToken(
     if (results) return results;
 
     oidcLogger.warn(
-      { stage: 'validateBearerToken', issuers: allIssuers, err: lastError?.message },
+      { stage: 'validateBearerToken', issuers: allIssuers, err: errorState.last?.message },
       'JWT validation failed for all issuers, trying userinfo fallback',
     );
   }


### PR DESCRIPTION
Addresses all unresolved Copilot review comments from PRs #275, #277, #279.

### OIDC Middleware
- Reset `trustedIssuers` at start of `initOidc()` so re-init reflects current env
- Capture and log the last JWT error message when all issuers fail
- Use `stage` instead of `route` for the `validateBearerToken` log field (avoids semantic confusion with HTTP path)
- Use `instanceof Error` guard instead of unsafe `as Error` cast in catch blocks

### Auth Middleware
- Hash Bearer token with SHA-256 prefix instead of logging raw token preview (security)
- Separate warn vs info: only `token_rejected` logs at warn, `no_credentials` logs at info (reduces noise)
- Use consistent `reason` field across log, audit event, and InfluxDB metrics (was inconsistent)

### Results
- All 434 tests pass
- ESLint clean