### PR TITLE
Add battery level to snapshot and scooter summary

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -248,6 +248,7 @@ export async function initDatabase(): Promise<void> {
         user_sub TEXT NOT NULL,
         serial_number TEXT NOT NULL,
         battery INTEGER,
+        estimated_range DOUBLE PRECISION,
         odometer DOUBLE PRECISION,
         total_runtime INTEGER,
         total_ride_time INTEGER,
@@ -262,8 +263,9 @@ export async function initDatabase(): Promise<void> {
       );
       CREATE INDEX IF NOT EXISTS idx_gt3_snapshots_user ON gt3_snapshots (user_sub, timestamp DESC);
 
-      -- Add battery column if missing (existing tables)
+      -- Add columns if missing (existing tables)
       ALTER TABLE gt3_snapshots ADD COLUMN IF NOT EXISTS battery INTEGER;
+      ALTER TABLE gt3_snapshots ADD COLUMN IF NOT EXISTS estimated_range DOUBLE PRECISION;
     `);
     dbLogger.info('Database tables initialized');
   } catch (err) {

--- a/src/db.ts
+++ b/src/db.ts
@@ -247,6 +247,7 @@ export async function initDatabase(): Promise<void> {
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
         user_sub TEXT NOT NULL,
         serial_number TEXT NOT NULL,
+        battery INTEGER,
         odometer DOUBLE PRECISION,
         total_runtime INTEGER,
         total_ride_time INTEGER,
@@ -260,6 +261,9 @@ export async function initDatabase(): Promise<void> {
         created_at TIMESTAMPTZ DEFAULT NOW()
       );
       CREATE INDEX IF NOT EXISTS idx_gt3_snapshots_user ON gt3_snapshots (user_sub, timestamp DESC);
+
+      -- Add battery column if missing (existing tables)
+      ALTER TABLE gt3_snapshots ADD COLUMN IF NOT EXISTS battery INTEGER;
     `);
     dbLogger.info('Database tables initialized');
   } catch (err) {

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -86,22 +86,29 @@ router.post('/snapshot', async (req, res) => {
       });
     }
     await pool.query(
-      `INSERT INTO gt3_snapshots (user_sub, serial_number, battery, odometer, total_runtime, total_ride_time,
+      `INSERT INTO gt3_snapshots (user_sub, serial_number, battery, estimated_range, odometer, total_runtime, total_ride_time,
         bms1_cycle_count, bms2_cycle_count, bms1_energy_throughput, bms2_energy_throughput,
         firmware_versions, settings, timestamp)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
-      [userSub, s.serialNumber, s.battery ?? null, s.odometer, s.totalRuntime, s.totalRideTime,
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+      [userSub, s.serialNumber, s.battery ?? null, s.estimatedRange ?? null,
+        s.odometer, s.totalRuntime, s.totalRideTime,
         s.bms1CycleCount, s.bms2CycleCount, s.bms1EnergyThroughput, s.bms2EnergyThroughput,
         fwVersions, settings, s.timestamp || new Date()],
     );
-    writePoint('gt3_snapshot', {
+    const snapshotFields: Record<string, number> = {
       odometer: s.odometer ?? 0,
       total_runtime: s.totalRuntime ?? 0,
       total_ride_time: s.totalRideTime ?? 0,
       bms1_cycles: s.bms1CycleCount ?? 0,
       bms2_cycles: s.bms2CycleCount ?? 0,
-      battery: s.battery ?? 0,
-    }, { scooter: s.serialNumber || 'GT3Pro' });
+    };
+    if (s.battery != null) {
+      snapshotFields.battery = s.battery;
+    }
+    if (s.estimatedRange != null) {
+      snapshotFields.estimated_range = s.estimatedRange;
+    }
+    writePoint('gt3_snapshot', snapshotFields, { scooter: s.serialNumber || 'GT3Pro' });
     gt3Logger.info('Stored snapshot');
     return res.json({ ok: true });
   } catch (err) {

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -86,11 +86,11 @@ router.post('/snapshot', async (req, res) => {
       });
     }
     await pool.query(
-      `INSERT INTO gt3_snapshots (user_sub, serial_number, odometer, total_runtime, total_ride_time,
+      `INSERT INTO gt3_snapshots (user_sub, serial_number, battery, odometer, total_runtime, total_ride_time,
         bms1_cycle_count, bms2_cycle_count, bms1_energy_throughput, bms2_energy_throughput,
         firmware_versions, settings, timestamp)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
-      [userSub, s.serialNumber, s.odometer, s.totalRuntime, s.totalRideTime,
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
+      [userSub, s.serialNumber, s.battery ?? null, s.odometer, s.totalRuntime, s.totalRideTime,
         s.bms1CycleCount, s.bms2CycleCount, s.bms1EnergyThroughput, s.bms2EnergyThroughput,
         fwVersions, settings, s.timestamp || new Date()],
     );
@@ -100,6 +100,7 @@ router.post('/snapshot', async (req, res) => {
       total_ride_time: s.totalRideTime ?? 0,
       bms1_cycles: s.bms1CycleCount ?? 0,
       bms2_cycles: s.bms2CycleCount ?? 0,
+      battery: s.battery ?? 0,
     }, { scooter: s.serialNumber || 'GT3Pro' });
     gt3Logger.info('Stored snapshot');
     return res.json({ ok: true });

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -86,9 +86,10 @@ router.post('/snapshot', async (req, res) => {
       });
     }
     await pool.query(
-      `INSERT INTO gt3_snapshots (user_sub, serial_number, battery, estimated_range, odometer, total_runtime, total_ride_time,
-        bms1_cycle_count, bms2_cycle_count, bms1_energy_throughput, bms2_energy_throughput,
-        firmware_versions, settings, timestamp)
+      `INSERT INTO gt3_snapshots (user_sub, serial_number, battery,
+        estimated_range, odometer, total_runtime, total_ride_time,
+        bms1_cycle_count, bms2_cycle_count, bms1_energy_throughput,
+        bms2_energy_throughput, firmware_versions, settings, timestamp)
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
       [userSub, s.serialNumber, s.battery ?? null, s.estimatedRange ?? null,
         s.odometer, s.totalRuntime, s.totalRideTime,

--- a/src/server.ts
+++ b/src/server.ts
@@ -389,7 +389,7 @@ export async function createServer(): Promise<Express> {
         const userSub = req.user.sub;
         const [snapshotResult, lastRideResult] = await Promise.all([
           dbPool.query(
-            `SELECT odometer, total_ride_time, bms1_cycle_count, bms2_cycle_count, timestamp
+            `SELECT battery, odometer, total_ride_time, bms1_cycle_count, bms2_cycle_count, timestamp
              FROM gt3_snapshots WHERE user_sub = $1 ORDER BY timestamp DESC LIMIT 1`,
             [userSub],
           ),
@@ -405,6 +405,7 @@ export async function createServer(): Promise<Express> {
         if (snapshot || lastRide) {
           scooterSummary = {
             timestamp: snapshot?.timestamp || new Date().toISOString(),
+            battery: snapshot?.battery ?? null,
             odometer: snapshot?.odometer ?? null,
             totalRideTime: snapshot?.total_ride_time ?? null,
             batteryCycles: (snapshot?.bms1_cycle_count ?? 0) + (snapshot?.bms2_cycle_count ?? 0),

--- a/src/server.ts
+++ b/src/server.ts
@@ -389,7 +389,7 @@ export async function createServer(): Promise<Express> {
         const userSub = req.user.sub;
         const [snapshotResult, lastRideResult] = await Promise.all([
           dbPool.query(
-            `SELECT battery, odometer, total_ride_time, bms1_cycle_count, bms2_cycle_count, timestamp
+            `SELECT battery, estimated_range, odometer, total_ride_time, bms1_cycle_count, bms2_cycle_count, timestamp
              FROM gt3_snapshots WHERE user_sub = $1 ORDER BY timestamp DESC LIMIT 1`,
             [userSub],
           ),
@@ -406,6 +406,7 @@ export async function createServer(): Promise<Express> {
           scooterSummary = {
             timestamp: snapshot?.timestamp || new Date().toISOString(),
             battery: snapshot?.battery ?? null,
+            estimatedRange: snapshot?.estimated_range ?? null,
             odometer: snapshot?.odometer ?? null,
             totalRideTime: snapshot?.total_ride_time ?? null,
             batteryCycles: (snapshot?.bms1_cycle_count ?? 0) + (snapshot?.bms2_cycle_count ?? 0),


### PR DESCRIPTION
Adds battery tracking to GT3 snapshots so the FluxHaus dashboard can display current scooter battery level.

**Changes:**
- `src/db.ts`: Add `battery INTEGER` column with ALTER TABLE migration
- `src/routes/gt3.routes.ts`: Include battery in INSERT + InfluxDB write
- `src/server.ts`: Include battery in scooter summary response

Companion app PR: djensenius/gt3pro#103