### PR TITLE
GT3: Normalized samples table, missing telemetry fields, Postgres-first queries

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -266,6 +266,37 @@ export async function initDatabase(): Promise<void> {
       -- Add columns if missing (existing tables)
       ALTER TABLE gt3_snapshots ADD COLUMN IF NOT EXISTS battery INTEGER;
       ALTER TABLE gt3_snapshots ADD COLUMN IF NOT EXISTS estimated_range DOUBLE PRECISION;
+
+      CREATE TABLE IF NOT EXISTS gt3_samples (
+        id BIGSERIAL PRIMARY KEY,
+        ride_id UUID NOT NULL REFERENCES gt3_rides(id) ON DELETE CASCADE,
+        timestamp TIMESTAMPTZ NOT NULL,
+        speed DOUBLE PRECISION DEFAULT 0,
+        battery INTEGER DEFAULT 0,
+        bms_voltage DOUBLE PRECISION DEFAULT 0,
+        bms_current DOUBLE PRECISION DEFAULT 0,
+        bms_soc INTEGER DEFAULT 0,
+        bms_temp DOUBLE PRECISION DEFAULT 0,
+        body_temp DOUBLE PRECISION DEFAULT 0,
+        gear_mode INTEGER DEFAULT 0,
+        trip_distance DOUBLE PRECISION DEFAULT 0,
+        trip_time INTEGER DEFAULT 0,
+        range_estimate DOUBLE PRECISION DEFAULT 0,
+        error_code INTEGER DEFAULT 0,
+        warn_code INTEGER DEFAULT 0,
+        regen_level INTEGER DEFAULT 0,
+        speed_response INTEGER DEFAULT 0,
+        latitude DOUBLE PRECISION,
+        longitude DOUBLE PRECISION,
+        altitude DOUBLE PRECISION,
+        gps_speed DOUBLE PRECISION,
+        gps_course DOUBLE PRECISION,
+        horizontal_accuracy DOUBLE PRECISION,
+        roughness_score DOUBLE PRECISION,
+        max_acceleration DOUBLE PRECISION,
+        heart_rate INTEGER
+      );
+      CREATE INDEX IF NOT EXISTS idx_gt3_samples_ride ON gt3_samples (ride_id, timestamp);
     `);
     dbLogger.info('Database tables initialized');
   } catch (err) {

--- a/src/public/gt3/ride-detail.js
+++ b/src/public/gt3/ride-detail.js
@@ -53,11 +53,59 @@ function formatDuration(startIso, endIso) {
   return min < 60 ? `${min} min` : `${Math.floor(min / 60)}h ${min % 60}m`;
 }
 
+// Handle both InfluxDB (_time) and Postgres (timestamp) column names
+function sampleTime(s) {
+  return s._time || s.time || s.timestamp;
+}
+
 function formatTime(iso) {
   if (!iso) return '';
   return new Date(iso).toLocaleTimeString(undefined, {
     hour: '2-digit', minute: '2-digit', second: '2-digit',
   });
+}
+
+const defaultChartOptions = {
+  responsive: true,
+  plugins: { legend: { position: 'top' } },
+  scales: { x: { display: true, ticks: { maxTicksLimit: 10 } } },
+  elements: { point: { radius: 0 }, line: { borderWidth: 2 } },
+};
+
+function hideCard(canvasId) {
+  document.getElementById(canvasId).parentElement.style.display = 'none';
+}
+
+// ── GPX Export ────────────────────────────────────────────
+
+function buildGPX(samples, rideName) {
+  const points = samples
+    .filter(s => {
+      const lat = parseFloat(s.latitude);
+      const lon = parseFloat(s.longitude);
+      return lat && lon && lat !== 0 && lon !== 0;
+    })
+    .map(s => {
+      const time = sampleTime(s);
+      const ele = parseFloat(s.altitude) || 0;
+      return `      <trkpt lat="${s.latitude}" lon="${s.longitude}">
+        <ele>${ele}</ele>
+        ${time ? `<time>${new Date(time).toISOString()}</time>` : ''}
+      </trkpt>`;
+    });
+
+  if (points.length === 0) return null;
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="GT3 Pro Dashboard"
+  xmlns="http://www.topografix.com/GPX/1/1">
+  <trk>
+    <name>${rideName}</name>
+    <trkseg>
+${points.join('\n')}
+    </trkseg>
+  </trk>
+</gpx>`;
 }
 
 // ── Main ──────────────────────────────────────────────────
@@ -109,12 +157,44 @@ async function loadRide() {
       <div class="stat-value">${gearName(ride.gear_mode)}</div>
       <div class="stat-label">Gear Mode</div>
     </div>
-    ${ride.weather_temp != null ? `
-    <div class="stat-card">
-      <div class="stat-value">${ride.weather_temp.toFixed(0)}°C ${ride.weather_condition || ''}</div>
-      <div class="stat-label">Weather</div>
-    </div>` : ''}
   `;
+
+  // ── Weather ─────────────────────────────────────────────
+  if (ride.weather_temp != null) {
+    const ws = document.getElementById('weather-section');
+    ws.style.display = '';
+    document.getElementById('weather-detail').innerHTML = `
+      <div class="stat-card">
+        <div class="stat-value">${ride.weather_temp.toFixed(0)}°C</div>
+        <div class="stat-label">${ride.weather_condition || 'Temperature'}</div>
+      </div>
+      ${ride.weather_feels_like != null ? `
+      <div class="stat-card">
+        <div class="stat-value">${ride.weather_feels_like.toFixed(0)}°C</div>
+        <div class="stat-label">Feels Like</div>
+      </div>` : ''}
+      ${ride.weather_humidity != null ? `
+      <div class="stat-card">
+        <div class="stat-value">${ride.weather_humidity.toFixed(0)}%</div>
+        <div class="stat-label">Humidity</div>
+      </div>` : ''}
+      ${ride.weather_wind_speed != null ? `
+      <div class="stat-card">
+        <div class="stat-value">${ride.weather_wind_speed.toFixed(0)} km/h</div>
+        <div class="stat-label">Wind</div>
+      </div>` : ''}
+      ${ride.weather_uv_index != null ? `
+      <div class="stat-card">
+        <div class="stat-value">${ride.weather_uv_index.toFixed(0)}</div>
+        <div class="stat-label">UV Index</div>
+      </div>` : ''}
+      ${ride.weather_pressure != null ? `
+      <div class="stat-card">
+        <div class="stat-value">${ride.weather_pressure.toFixed(0)} hPa</div>
+        <div class="stat-label">Pressure</div>
+      </div>` : ''}
+    `;
+  }
 
   // ── Map ─────────────────────────────────────────────────
   if (ride.gps_track && Array.isArray(ride.gps_track) && ride.gps_track.length > 0) {
@@ -124,7 +204,6 @@ async function loadRide() {
       maxZoom: 19,
     }).addTo(map);
 
-    // gps_track: array of [lng, lat, alt?] (GeoJSON order) or {lat, lng} objects
     const latLngs = ride.gps_track.map(coord => {
       if (Array.isArray(coord)) return [coord[1], coord[0]];
       return [coord.latitude ?? coord.lat, coord.longitude ?? coord.lng];
@@ -154,14 +233,7 @@ async function loadRide() {
   // ── Telemetry charts ────────────────────────────────────
   if (samplesData && samplesData.samples && samplesData.samples.length > 0) {
     const samples = samplesData.samples;
-    const times = samples.map(s => formatTime(s._time || s.time));
-
-    const chartOptions = {
-      responsive: true,
-      plugins: { legend: { position: 'top' } },
-      scales: { x: { display: true, ticks: { maxTicksLimit: 10 } } },
-      elements: { point: { radius: 0 }, line: { borderWidth: 2 } },
-    };
+    const times = samples.map(s => formatTime(sampleTime(s)));
 
     // Speed
     new Chart(document.getElementById('speedChart'), {
@@ -176,13 +248,13 @@ async function loadRide() {
           fill: true, tension: 0.2,
         }, {
           label: 'GPS Speed (km/h)',
-          data: samples.map(s => parseFloat(s.gps_speed) || 0),
+          data: samples.map(s => parseFloat(s.gps_speed || s.gpsSpeed) || 0),
           borderColor: CHART_COLORS.sapphire,
           borderDash: [5, 5],
           fill: false, tension: 0.2,
         }],
       },
-      options: chartOptions,
+      options: defaultChartOptions,
     });
 
     // Battery & BMS
@@ -197,25 +269,55 @@ async function loadRide() {
           fill: false, tension: 0.2, yAxisID: 'y',
         }, {
           label: 'BMS Voltage (V)',
-          data: samples.map(s => parseFloat(s.bms_voltage) || 0),
+          data: samples.map(s => parseFloat(s.bms_voltage || s.bmsVoltage) || 0),
           borderColor: CHART_COLORS.yellow,
           fill: false, tension: 0.2, yAxisID: 'y1',
         }, {
           label: 'BMS Current (A)',
-          data: samples.map(s => parseFloat(s.bms_current) || 0),
+          data: samples.map(s => parseFloat(s.bms_current || s.bmsCurrent) || 0),
           borderColor: CHART_COLORS.peach,
           fill: false, tension: 0.2, yAxisID: 'y1',
         }],
       },
       options: {
-        ...chartOptions,
+        ...defaultChartOptions,
         scales: {
-          ...chartOptions.scales,
+          ...defaultChartOptions.scales,
           y: { position: 'left', title: { display: true, text: 'Battery %' }, min: 0, max: 100 },
           y1: { position: 'right', title: { display: true, text: 'V / A' }, grid: { drawOnChartArea: false } },
         },
       },
     });
+
+    // Temperature (BMS + Body)
+    const hasBmsTemp = samples.some(s => parseFloat(s.bms_temp || s.bmsTemp) > 0);
+    const hasBodyTemp = samples.some(s => parseFloat(s.body_temp || s.bodyTemp) > 0);
+    if (hasBmsTemp || hasBodyTemp) {
+      const datasets = [];
+      if (hasBmsTemp) {
+        datasets.push({
+          label: 'BMS Temp (°C)',
+          data: samples.map(s => parseFloat(s.bms_temp || s.bmsTemp) || null),
+          borderColor: CHART_COLORS.peach,
+          fill: false, tension: 0.3, spanGaps: true,
+        });
+      }
+      if (hasBodyTemp) {
+        datasets.push({
+          label: 'Body Temp (°C)',
+          data: samples.map(s => parseFloat(s.body_temp || s.bodyTemp) || null),
+          borderColor: CHART_COLORS.yellow,
+          fill: false, tension: 0.3, spanGaps: true,
+        });
+      }
+      new Chart(document.getElementById('tempChart'), {
+        type: 'line',
+        data: { labels: times, datasets },
+        options: defaultChartOptions,
+      });
+    } else {
+      hideCard('tempChart');
+    }
 
     // Altitude
     const hasAlt = samples.some(s => {
@@ -235,31 +337,74 @@ async function loadRide() {
             fill: true, tension: 0.3, spanGaps: true,
           }],
         },
-        options: chartOptions,
+        options: defaultChartOptions,
       });
     } else {
-      document.getElementById('altitudeChart').parentElement.style.display = 'none';
+      hideCard('altitudeChart');
     }
 
     // Heart rate
-    const hrSamples = samples.filter(s => parseFloat(s.heart_rate) > 0);
+    const hrSamples = samples.filter(s => parseFloat(s.heart_rate || s.heartRate) > 0);
     if (hrSamples.length > 0) {
       new Chart(document.getElementById('heartRateChart'), {
         type: 'line',
         data: {
-          labels: hrSamples.map(s => formatTime(s._time || s.time)),
+          labels: hrSamples.map(s => formatTime(sampleTime(s))),
           datasets: [{
             label: 'Heart Rate (bpm)',
-            data: hrSamples.map(s => parseFloat(s.heart_rate)),
+            data: hrSamples.map(s => parseFloat(s.heart_rate || s.heartRate)),
             borderColor: CHART_COLORS.red,
             backgroundColor: CHART_COLORS.red + '20',
             fill: true, tension: 0.3,
           }],
         },
-        options: chartOptions,
+        options: defaultChartOptions,
       });
     } else {
-      document.getElementById('heartRateChart').parentElement.style.display = 'none';
+      hideCard('heartRateChart');
+    }
+
+    // Surface roughness
+    const hasRoughness = samples.some(s => parseFloat(s.roughness_score || s.roughnessScore) > 0);
+    if (hasRoughness) {
+      new Chart(document.getElementById('roughnessChart'), {
+        type: 'line',
+        data: {
+          labels: times,
+          datasets: [{
+            label: 'Roughness Score',
+            data: samples.map(s => parseFloat(s.roughness_score || s.roughnessScore) || null),
+            borderColor: CHART_COLORS.mauve,
+            backgroundColor: CHART_COLORS.mauve + '20',
+            fill: true, tension: 0.3, spanGaps: true,
+          }, {
+            label: 'Max Acceleration (g)',
+            data: samples.map(s => parseFloat(s.max_acceleration || s.maxAcceleration) || null),
+            borderColor: CHART_COLORS.pink,
+            borderDash: [5, 5],
+            fill: false, tension: 0.3, spanGaps: true,
+          }],
+        },
+        options: defaultChartOptions,
+      });
+    } else {
+      hideCard('roughnessChart');
+    }
+
+    // GPX export button
+    const gpxData = buildGPX(samples, `Ride ${formatDate(ride.start_time)}`);
+    if (gpxData) {
+      const btn = document.getElementById('gpx-export');
+      btn.style.display = '';
+      btn.onclick = () => {
+        const blob = new Blob([gpxData], { type: 'application/gpx+xml' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `gt3-ride-${rideId.slice(0, 8)}.gpx`;
+        a.click();
+        URL.revokeObjectURL(url);
+      };
     }
   } else {
     document.querySelectorAll('.charts-grid .card').forEach(card => {

--- a/src/public/gt3/ride.html
+++ b/src/public/gt3/ride.html
@@ -21,6 +21,11 @@
             <div class="stat-card"><div class="loading"><div class="spinner"></div></div></div>
         </section>
 
+        <section id="weather-section" class="card" style="display:none;">
+            <h3>🌤 Weather</h3>
+            <div id="weather-detail" class="stats-grid"></div>
+        </section>
+
         <section id="map-section" class="card">
             <h3>Route</h3>
             <div id="map" style="height: 400px; border-radius: 8px;"></div>
@@ -36,6 +41,10 @@
                 <canvas id="batteryChart"></canvas>
             </div>
             <div class="card">
+                <h3>Temperature</h3>
+                <canvas id="tempChart"></canvas>
+            </div>
+            <div class="card">
                 <h3>Altitude</h3>
                 <canvas id="altitudeChart"></canvas>
             </div>
@@ -43,6 +52,14 @@
                 <h3>Heart Rate</h3>
                 <canvas id="heartRateChart"></canvas>
             </div>
+            <div class="card">
+                <h3>Surface Roughness</h3>
+                <canvas id="roughnessChart"></canvas>
+            </div>
+        </section>
+
+        <section class="card" style="text-align:center; padding: 1.5rem;">
+            <button id="gpx-export" style="display:none;">📥 Export GPX</button>
         </section>
     </main>
     <script src="/gt3/ride-detail.js"></script>

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -40,11 +40,15 @@ router.post('/telemetry', async (req, res) => {
         error_code: sample.errorCode ?? 0,
         warn_code: sample.warnCode ?? 0,
         regen_level: sample.regenLevel ?? 0,
+        speed_response: sample.speedResponse ?? 0,
         latitude: sample.latitude ?? 0,
         longitude: sample.longitude ?? 0,
         altitude: sample.altitude ?? 0,
         gps_speed: sample.gpsSpeed ?? 0,
+        gps_course: sample.gpsCourse ?? 0,
+        horizontal_accuracy: sample.horizontalAccuracy ?? 0,
         roughness_score: sample.roughnessScore ?? 0,
+        max_acceleration: sample.maxAcceleration ?? 0,
         heart_rate: sample.heartRate ?? 0,
       }, { scooter: 'GT3Pro' });
 
@@ -158,6 +162,48 @@ router.post('/ride', async (req, res) => {
       rideFields.weather_wind_speed = r.weather.windSpeed ?? 0;
     }
     writePoint('gt3_ride', rideFields, { scooter: 'GT3Pro', ride_id: rideId || 'unknown' });
+
+    // Insert per-ride samples into normalized Postgres table
+    if (rideId && Array.isArray(r.samples) && r.samples.length > 0) {
+      const sampleValues: unknown[] = [];
+      const placeholders: string[] = [];
+      let paramIdx = 1;
+      for (const s of r.samples) {
+        placeholders.push(
+          `($${paramIdx},$${paramIdx + 1},$${paramIdx + 2},$${paramIdx + 3},$${paramIdx + 4},` +
+          `$${paramIdx + 5},$${paramIdx + 6},$${paramIdx + 7},$${paramIdx + 8},$${paramIdx + 9},` +
+          `$${paramIdx + 10},$${paramIdx + 11},$${paramIdx + 12},$${paramIdx + 13},$${paramIdx + 14},` +
+          `$${paramIdx + 15},$${paramIdx + 16},$${paramIdx + 17},$${paramIdx + 18},$${paramIdx + 19},` +
+          `$${paramIdx + 20},$${paramIdx + 21},$${paramIdx + 22},$${paramIdx + 23},$${paramIdx + 24},` +
+          `$${paramIdx + 25})`,
+        );
+        sampleValues.push(
+          rideId, s.timestamp, s.speed ?? 0, s.battery ?? 0,
+          s.bmsVoltage ?? 0, s.bmsCurrent ?? 0, s.bmsSOC ?? 0, s.bmsTemp ?? 0,
+          s.bodyTemp ?? 0, s.gearMode ?? 0, s.tripDistance ?? 0, s.tripTime ?? 0,
+          s.estimatedRange ?? 0, s.errorCode ?? 0, s.warnCode ?? 0,
+          s.regenLevel ?? 0, s.speedResponse ?? 0,
+          s.latitude ?? null, s.longitude ?? null, s.altitude ?? null,
+          s.gpsSpeed ?? null, s.gpsCourse ?? null, s.horizontalAccuracy ?? null,
+          s.roughnessScore ?? null, s.maxAcceleration ?? null, s.heartRate ?? null,
+        );
+        paramIdx += 26;
+      }
+      await pool.query(
+        `INSERT INTO gt3_samples (ride_id, timestamp, speed, battery,
+          bms_voltage, bms_current, bms_soc, bms_temp,
+          body_temp, gear_mode, trip_distance, trip_time,
+          range_estimate, error_code, warn_code,
+          regen_level, speed_response,
+          latitude, longitude, altitude,
+          gps_speed, gps_course, horizontal_accuracy,
+          roughness_score, max_acceleration, heart_rate)
+         VALUES ${placeholders.join(',')}`,
+        sampleValues,
+      );
+      gt3Logger.info({ rideId, sampleCount: r.samples.length }, 'Stored ride samples');
+    }
+
     gt3Logger.info({ rideId }, 'Stored ride');
     return res.json({ ok: true, id: rideId });
   } catch (err) {
@@ -257,16 +303,33 @@ router.get('/rides/:id/samples', async (req, res) => {
   if (!pool) return res.status(503).json({ error: 'Database unavailable' });
   try {
     const userSub = req.user?.sub || 'unknown';
-    // Get the ride's time range from PostgreSQL
+    // Verify ride belongs to user
     const rideResult = await pool.query(
       'SELECT start_time, end_time FROM gt3_rides WHERE id = $1 AND user_sub = $2',
       [req.params.id, userSub],
     );
     if (rideResult.rows.length === 0) return res.status(404).json({ error: 'Ride not found' });
+
+    // Try Postgres samples first (normalized table)
+    const pgSamples = await pool.query(
+      `SELECT timestamp, speed, battery, bms_voltage, bms_current, bms_soc, bms_temp,
+        body_temp, gear_mode, trip_distance, trip_time, range_estimate,
+        error_code, warn_code, regen_level, speed_response,
+        latitude, longitude, altitude, gps_speed, gps_course,
+        horizontal_accuracy, roughness_score, max_acceleration, heart_rate
+       FROM gt3_samples WHERE ride_id = $1 ORDER BY timestamp`,
+      [req.params.id],
+    );
+
+    if (pgSamples.rows.length > 0) {
+      return res.json({ samples: pgSamples.rows, rideId: req.params.id, source: 'postgres' });
+    }
+
+    // Fallback to InfluxDB for older rides without Postgres samples
     const { start_time: startTime, end_time: endTime } = rideResult.rows[0];
 
     if (!influxQuery.configured) {
-      return res.status(503).json({ error: 'InfluxDB not configured' });
+      return res.json({ samples: [], rideId: req.params.id, source: 'none' });
     }
 
     const startISO = new Date(startTime).toISOString();
@@ -280,7 +343,7 @@ router.get('/rides/:id/samples', async (req, res) => {
   |> sort(columns: ["_time"])`;
 
     const samples = await influxQuery.query(flux);
-    return res.json({ samples, rideId: req.params.id });
+    return res.json({ samples, rideId: req.params.id, source: 'influxdb' });
   } catch (err) {
     gt3Logger.error({ err }, 'Failed to get ride samples');
     return res.status(500).json({ error: 'Internal server error' });

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -171,51 +171,82 @@ router.post('/ride', async (req, res) => {
     if (rideId && Array.isArray(r.samples) && r.samples.length > 0) {
       const BATCH_SIZE = 500;
       const COLS_PER_ROW = 26;
-      for (let i = 0; i < r.samples.length; i += BATCH_SIZE) {
-        const batch = r.samples.slice(i, i + BATCH_SIZE);
-        const sampleValues: unknown[] = [];
-        const placeholders: string[] = [];
-        let paramIdx = 1;
-        for (const s of batch) {
-          // Validate timestamp
-          const ts = s.timestamp ? new Date(s.timestamp) : null;
-          if (!ts || isNaN(ts.getTime())) continue;
 
-          placeholders.push(
-            `($${paramIdx},$${paramIdx + 1},$${paramIdx + 2},$${paramIdx + 3},$${paramIdx + 4},` +
-            `$${paramIdx + 5},$${paramIdx + 6},$${paramIdx + 7},$${paramIdx + 8},$${paramIdx + 9},` +
-            `$${paramIdx + 10},$${paramIdx + 11},$${paramIdx + 12},$${paramIdx + 13},$${paramIdx + 14},` +
-            `$${paramIdx + 15},$${paramIdx + 16},$${paramIdx + 17},$${paramIdx + 18},$${paramIdx + 19},` +
-            `$${paramIdx + 20},$${paramIdx + 21},$${paramIdx + 22},$${paramIdx + 23},$${paramIdx + 24},` +
-            `$${paramIdx + 25})`,
+      // Filter and validate samples
+      const validSamples = r.samples
+        .map((s: Record<string, unknown>) => {
+          const ts = s.timestamp ? new Date(s.timestamp as string) : null;
+          if (!ts || Number.isNaN(ts.getTime())) return null;
+          return { ...s, validTimestamp: ts.toISOString() };
+        })
+        .filter(Boolean) as Array<Record<string, unknown>>;
+
+      // Build batches
+      const batches: Array<{ placeholders: string[]; values: unknown[] }> = [];
+      let idx = 0;
+      while (idx < validSamples.length) {
+        const chunk = validSamples.slice(idx, idx + BATCH_SIZE);
+        const batchPlaceholders: string[] = [];
+        const batchValues: unknown[] = [];
+        chunk.forEach((s, rowIdx) => {
+          const p = rowIdx * COLS_PER_ROW + 1;
+          batchPlaceholders.push(
+            `($${p},$${p + 1},$${p + 2},$${p + 3},$${p + 4}`
+            + `,$${p + 5},$${p + 6},$${p + 7},$${p + 8},$${p + 9}`
+            + `,$${p + 10},$${p + 11},$${p + 12},$${p + 13},$${p + 14}`
+            + `,$${p + 15},$${p + 16},$${p + 17},$${p + 18},$${p + 19}`
+            + `,$${p + 20},$${p + 21},$${p + 22},$${p + 23},$${p + 24}`
+            + `,$${p + 25})`,
           );
-          sampleValues.push(
-            rideId, ts.toISOString(), s.speed ?? 0, s.battery ?? 0,
-            s.bmsVoltage ?? 0, s.bmsCurrent ?? 0, s.bmsSOC ?? 0, s.bmsTemp ?? 0,
-            s.bodyTemp ?? 0, s.gearMode ?? 0, s.tripDistance ?? 0, s.tripTime ?? 0,
-            s.estimatedRange ?? 0, s.errorCode ?? 0, s.warnCode ?? 0,
-            s.regenLevel ?? 0, s.speedResponse ?? 0,
-            s.latitude ?? null, s.longitude ?? null, s.altitude ?? null,
-            s.gpsSpeed ?? null, s.gpsCourse ?? null, s.horizontalAccuracy ?? null,
-            s.roughnessScore ?? null, s.maxAcceleration ?? null, s.heartRate ?? null,
+          batchValues.push(
+            rideId,
+            s.validTimestamp,
+            s.speed ?? 0,
+            s.battery ?? 0,
+            s.bmsVoltage ?? 0,
+            s.bmsCurrent ?? 0,
+            s.bmsSOC ?? 0,
+            s.bmsTemp ?? 0,
+            s.bodyTemp ?? 0,
+            s.gearMode ?? 0,
+            s.tripDistance ?? 0,
+            s.tripTime ?? 0,
+            s.estimatedRange ?? 0,
+            s.errorCode ?? 0,
+            s.warnCode ?? 0,
+            s.regenLevel ?? 0,
+            s.speedResponse ?? 0,
+            s.latitude ?? null,
+            s.longitude ?? null,
+            s.altitude ?? null,
+            s.gpsSpeed ?? null,
+            s.gpsCourse ?? null,
+            s.horizontalAccuracy ?? null,
+            s.roughnessScore ?? null,
+            s.maxAcceleration ?? null,
+            s.heartRate ?? null,
           );
-          paramIdx += COLS_PER_ROW;
-        }
-        if (placeholders.length > 0) {
-          await client.query(
-            `INSERT INTO gt3_samples (ride_id, timestamp, speed, battery,
-              bms_voltage, bms_current, bms_soc, bms_temp,
-              body_temp, gear_mode, trip_distance, trip_time,
-              range_estimate, error_code, warn_code,
-              regen_level, speed_response,
-              latitude, longitude, altitude,
-              gps_speed, gps_course, horizontal_accuracy,
-              roughness_score, max_acceleration, heart_rate)
-             VALUES ${placeholders.join(',')}`,
-            sampleValues,
-          );
-        }
+        });
+        batches.push({ placeholders: batchPlaceholders, values: batchValues });
+        idx += BATCH_SIZE;
       }
+
+      // Execute batch inserts sequentially
+      await batches.reduce(
+        (chain, batch) => chain.then(() => client.query(
+          `INSERT INTO gt3_samples (ride_id, timestamp, speed, battery,
+            bms_voltage, bms_current, bms_soc, bms_temp,
+            body_temp, gear_mode, trip_distance, trip_time,
+            range_estimate, error_code, warn_code,
+            regen_level, speed_response,
+            latitude, longitude, altitude,
+            gps_speed, gps_course, horizontal_accuracy,
+            roughness_score, max_acceleration, heart_rate)
+           VALUES ${batch.placeholders.join(',')}`,
+          batch.values,
+        )),
+        Promise.resolve() as Promise<unknown>,
+      );
       gt3Logger.info({ rideId, sampleCount: r.samples.length }, 'Stored ride samples');
     }
 

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -126,10 +126,14 @@ router.post('/snapshot', async (req, res) => {
 router.post('/ride', async (req, res) => {
   const pool = getPool();
   if (!pool) return res.status(503).json({ error: 'Database unavailable' });
+  const client = await pool.connect();
   try {
     const r = req.body;
     const userSub = req.user?.sub || 'unknown';
-    const result = await pool.query(
+
+    await client.query('BEGIN');
+
+    const result = await client.query(
       `INSERT INTO gt3_rides (user_sub, start_time, end_time, distance, max_speed, avg_speed,
         battery_used, start_battery, end_battery, gear_mode, gps_track, health_data, metadata,
         weather_temp, weather_feels_like, weather_humidity, weather_wind_speed,
@@ -163,52 +167,67 @@ router.post('/ride', async (req, res) => {
     }
     writePoint('gt3_ride', rideFields, { scooter: 'GT3Pro', ride_id: rideId || 'unknown' });
 
-    // Insert per-ride samples into normalized Postgres table
+    // Insert per-ride samples into normalized Postgres table (batched)
     if (rideId && Array.isArray(r.samples) && r.samples.length > 0) {
-      const sampleValues: unknown[] = [];
-      const placeholders: string[] = [];
-      let paramIdx = 1;
-      for (const s of r.samples) {
-        placeholders.push(
-          `($${paramIdx},$${paramIdx + 1},$${paramIdx + 2},$${paramIdx + 3},$${paramIdx + 4},` +
-          `$${paramIdx + 5},$${paramIdx + 6},$${paramIdx + 7},$${paramIdx + 8},$${paramIdx + 9},` +
-          `$${paramIdx + 10},$${paramIdx + 11},$${paramIdx + 12},$${paramIdx + 13},$${paramIdx + 14},` +
-          `$${paramIdx + 15},$${paramIdx + 16},$${paramIdx + 17},$${paramIdx + 18},$${paramIdx + 19},` +
-          `$${paramIdx + 20},$${paramIdx + 21},$${paramIdx + 22},$${paramIdx + 23},$${paramIdx + 24},` +
-          `$${paramIdx + 25})`,
-        );
-        sampleValues.push(
-          rideId, s.timestamp, s.speed ?? 0, s.battery ?? 0,
-          s.bmsVoltage ?? 0, s.bmsCurrent ?? 0, s.bmsSOC ?? 0, s.bmsTemp ?? 0,
-          s.bodyTemp ?? 0, s.gearMode ?? 0, s.tripDistance ?? 0, s.tripTime ?? 0,
-          s.estimatedRange ?? 0, s.errorCode ?? 0, s.warnCode ?? 0,
-          s.regenLevel ?? 0, s.speedResponse ?? 0,
-          s.latitude ?? null, s.longitude ?? null, s.altitude ?? null,
-          s.gpsSpeed ?? null, s.gpsCourse ?? null, s.horizontalAccuracy ?? null,
-          s.roughnessScore ?? null, s.maxAcceleration ?? null, s.heartRate ?? null,
-        );
-        paramIdx += 26;
+      const BATCH_SIZE = 500;
+      const COLS_PER_ROW = 26;
+      for (let i = 0; i < r.samples.length; i += BATCH_SIZE) {
+        const batch = r.samples.slice(i, i + BATCH_SIZE);
+        const sampleValues: unknown[] = [];
+        const placeholders: string[] = [];
+        let paramIdx = 1;
+        for (const s of batch) {
+          // Validate timestamp
+          const ts = s.timestamp ? new Date(s.timestamp) : null;
+          if (!ts || isNaN(ts.getTime())) continue;
+
+          placeholders.push(
+            `($${paramIdx},$${paramIdx + 1},$${paramIdx + 2},$${paramIdx + 3},$${paramIdx + 4},` +
+            `$${paramIdx + 5},$${paramIdx + 6},$${paramIdx + 7},$${paramIdx + 8},$${paramIdx + 9},` +
+            `$${paramIdx + 10},$${paramIdx + 11},$${paramIdx + 12},$${paramIdx + 13},$${paramIdx + 14},` +
+            `$${paramIdx + 15},$${paramIdx + 16},$${paramIdx + 17},$${paramIdx + 18},$${paramIdx + 19},` +
+            `$${paramIdx + 20},$${paramIdx + 21},$${paramIdx + 22},$${paramIdx + 23},$${paramIdx + 24},` +
+            `$${paramIdx + 25})`,
+          );
+          sampleValues.push(
+            rideId, ts.toISOString(), s.speed ?? 0, s.battery ?? 0,
+            s.bmsVoltage ?? 0, s.bmsCurrent ?? 0, s.bmsSOC ?? 0, s.bmsTemp ?? 0,
+            s.bodyTemp ?? 0, s.gearMode ?? 0, s.tripDistance ?? 0, s.tripTime ?? 0,
+            s.estimatedRange ?? 0, s.errorCode ?? 0, s.warnCode ?? 0,
+            s.regenLevel ?? 0, s.speedResponse ?? 0,
+            s.latitude ?? null, s.longitude ?? null, s.altitude ?? null,
+            s.gpsSpeed ?? null, s.gpsCourse ?? null, s.horizontalAccuracy ?? null,
+            s.roughnessScore ?? null, s.maxAcceleration ?? null, s.heartRate ?? null,
+          );
+          paramIdx += COLS_PER_ROW;
+        }
+        if (placeholders.length > 0) {
+          await client.query(
+            `INSERT INTO gt3_samples (ride_id, timestamp, speed, battery,
+              bms_voltage, bms_current, bms_soc, bms_temp,
+              body_temp, gear_mode, trip_distance, trip_time,
+              range_estimate, error_code, warn_code,
+              regen_level, speed_response,
+              latitude, longitude, altitude,
+              gps_speed, gps_course, horizontal_accuracy,
+              roughness_score, max_acceleration, heart_rate)
+             VALUES ${placeholders.join(',')}`,
+            sampleValues,
+          );
+        }
       }
-      await pool.query(
-        `INSERT INTO gt3_samples (ride_id, timestamp, speed, battery,
-          bms_voltage, bms_current, bms_soc, bms_temp,
-          body_temp, gear_mode, trip_distance, trip_time,
-          range_estimate, error_code, warn_code,
-          regen_level, speed_response,
-          latitude, longitude, altitude,
-          gps_speed, gps_course, horizontal_accuracy,
-          roughness_score, max_acceleration, heart_rate)
-         VALUES ${placeholders.join(',')}`,
-        sampleValues,
-      );
       gt3Logger.info({ rideId, sampleCount: r.samples.length }, 'Stored ride samples');
     }
 
+    await client.query('COMMIT');
     gt3Logger.info({ rideId }, 'Stored ride');
     return res.json({ ok: true, id: rideId });
   } catch (err) {
+    await client.query('ROLLBACK');
     gt3Logger.error({ err }, 'Failed to store ride');
     return res.status(500).json({ error: 'Internal server error' });
+  } finally {
+    client.release();
   }
 });
 
@@ -322,7 +341,35 @@ router.get('/rides/:id/samples', async (req, res) => {
     );
 
     if (pgSamples.rows.length > 0) {
-      return res.json({ samples: pgSamples.rows, rideId: req.params.id, source: 'postgres' });
+      // Normalize column names to match InfluxDB format for consistent client parsing
+      const normalized = pgSamples.rows.map((row: Record<string, unknown>) => ({
+        _time: row.timestamp,
+        speed: row.speed,
+        battery: row.battery,
+        bms_voltage: row.bms_voltage,
+        bms_current: row.bms_current,
+        bms_soc: row.bms_soc,
+        bms_temp: row.bms_temp,
+        body_temp: row.body_temp,
+        gear_mode: row.gear_mode,
+        trip_distance: row.trip_distance,
+        trip_time: row.trip_time,
+        range_estimate: row.range_estimate,
+        error_code: row.error_code,
+        warn_code: row.warn_code,
+        regen_level: row.regen_level,
+        speed_response: row.speed_response,
+        latitude: row.latitude,
+        longitude: row.longitude,
+        altitude: row.altitude,
+        gps_speed: row.gps_speed,
+        gps_course: row.gps_course,
+        horizontal_accuracy: row.horizontal_accuracy,
+        roughness_score: row.roughness_score,
+        max_acceleration: row.max_acceleration,
+        heart_rate: row.heart_rate,
+      }));
+      return res.json({ samples: normalized, rideId: req.params.id, source: 'postgres' });
     }
 
     // Fallback to InfluxDB for older rides without Postgres samples


### PR DESCRIPTION
## Changes

### New `gt3_samples` Table
- Normalized Postgres table with `ride_id` FK → `gt3_rides` (CASCADE delete)
- All 25 telemetry fields: speed, battery, BMS, GPS (lat/lon/alt/speed/course/accuracy), roughness, heart rate
- Indexed on `(ride_id, timestamp)` for fast per-ride queries

### Sample Insertion on Ride Upload
- `POST /gt3/ride` now bulk-inserts all samples from the ride payload into `gt3_samples`
- Enables relational queries across rides (e.g. `WHERE speed > 80`)

### Postgres-First Sample Queries
- `GET /gt3/rides/:id/samples` queries Postgres first, falls back to InfluxDB for older rides
- Response includes `source` field (`postgres` / `influxdb` / `none`)

### Missing Telemetry Fields
- Added to InfluxDB `gt3_telemetry` write: `gps_course`, `horizontal_accuracy`, `speed_response`, `max_acceleration`

Companion PR: https://github.com/djensenius/gt3pro/pull/105