### PR TITLE
Fix JSONB serialization for ride GPS track upload

### DIFF
--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -142,7 +142,9 @@ router.post('/ride', async (req, res) => {
        RETURNING id`,
       [userSub, r.startTime, r.endTime, r.distance ?? r.totalDistance, r.maxSpeed, r.avgSpeed,
         r.batteryUsed, r.startBattery, r.endBattery, r.primaryGearMode ?? r.gearMode ?? null,
-        r.gpsTrack || null, r.healthData || null, r.metadata || null,
+        r.gpsTrack ? JSON.stringify(r.gpsTrack) : null,
+        r.healthData ? JSON.stringify(r.healthData) : null,
+        r.metadata ? JSON.stringify(r.metadata) : null,
         r.weather?.temp ?? null, r.weather?.feelsLike ?? null, r.weather?.humidity ?? null,
         r.weather?.windSpeed ?? null, r.weather?.windDirection ?? null,
         r.weather?.condition ?? null, r.weather?.uvIndex ?? null, r.weather?.pressure ?? null],
@@ -255,8 +257,9 @@ router.post('/ride', async (req, res) => {
     return res.json({ ok: true, id: rideId });
   } catch (err) {
     await client.query('ROLLBACK');
+    const detail = err instanceof Error ? err.message : String(err);
     gt3Logger.error({ err }, 'Failed to store ride');
-    return res.status(500).json({ error: 'Internal server error' });
+    return res.status(500).json({ error: 'Internal server error', detail });
   } finally {
     client.release();
   }


### PR DESCRIPTION
## Problem

`POST /gt3/ride` returns 500 for any ride that has GPS track data. Two rides have been stuck retrying for multiple sessions.

## Root Cause

`node-pg` serializes JavaScript arrays as PostgreSQL array literals (`{val1,val2}`), not as JSON strings. When passing `r.gpsTrack` (a nested JS array like `[[lon,lat,alt],...]`) directly to a JSONB column, PostgreSQL rejects the type mismatch.

Earlier rides worked because they had no GPS data (`gpsTrack` was `undefined`, which fell through to `null`).

## Fix

- Explicitly `JSON.stringify()` the `gpsTrack`, `healthData`, and `metadata` values before passing to the query
- Include error detail in the 500 response body for easier debugging