### PR TITLE
GT3 web: GPS distance, weather emoji, gear breakdown

### DIFF
--- a/src/public/gt3/dashboard.js
+++ b/src/public/gt3/dashboard.js
@@ -59,8 +59,10 @@ const WEATHER_EMOJI = {
 function weatherEmoji(condition) {
   if (!condition) return '';
   const lower = condition.toLowerCase();
-  for (const [key, emoji] of Object.entries(WEATHER_EMOJI)) {
-    if (lower.includes(key)) return emoji;
+  if (WEATHER_EMOJI[lower]) return WEATHER_EMOJI[lower];
+  const sortedKeys = Object.keys(WEATHER_EMOJI).sort((a, b) => b.length - a.length);
+  for (const key of sortedKeys) {
+    if (lower.includes(key)) return WEATHER_EMOJI[key];
   }
   return '🌡️';
 }

--- a/src/public/gt3/dashboard.js
+++ b/src/public/gt3/dashboard.js
@@ -44,6 +44,27 @@ function gearName(mode) {
   return GEAR_NAMES[mode] || `Mode ${mode}`;
 }
 
+// Weather condition → emoji mapping
+const WEATHER_EMOJI = {
+  clear: '☀️', sunny: '☀️',
+  'mostly clear': '🌤️', 'partly cloudy': '⛅',
+  cloudy: '☁️', overcast: '☁️', 'mostly cloudy': '🌥️',
+  rain: '🌧️', drizzle: '🌦️', showers: '🌦️', 'heavy rain': '🌧️',
+  thunderstorm: '⛈️', 'thunderstorms': '⛈️',
+  snow: '🌨️', sleet: '🌨️', 'freezing rain': '🌨️',
+  fog: '🌫️', haze: '🌫️', mist: '🌫️',
+  wind: '💨', windy: '💨', breezy: '💨',
+};
+
+function weatherEmoji(condition) {
+  if (!condition) return '';
+  const lower = condition.toLowerCase();
+  for (const [key, emoji] of Object.entries(WEATHER_EMOJI)) {
+    if (lower.includes(key)) return emoji;
+  }
+  return '🌡️';
+}
+
 function formatDistance(km) {
   if (km == null) return '—';
   return km < 1 ? `${(km * 1000).toFixed(0)} m` : `${km.toFixed(1)} km`;
@@ -196,7 +217,7 @@ async function loadRides(page = 1) {
       <td>${formatSpeed(r.avg_speed)}</td>
       <td><span class="battery-badge">${r.start_battery ?? '?'}% → ${r.end_battery ?? '?'}%</span></td>
       <td><span class="gear-badge gear-${r.gear_mode}">${gearName(r.gear_mode)}</span></td>
-      <td>${r.weather_temp != null ? `${r.weather_temp.toFixed(0)}°C` : '—'}</td>
+      <td>${r.weather_temp != null ? `${weatherEmoji(r.weather_condition)} ${r.weather_temp.toFixed(0)}°C` : '—'}</td>
       <td><a href="/gt3/ride.html?id=${r.id}" class="btn-small">Details →</a></td>
     </tr>
   `).join('');

--- a/src/public/gt3/ride-detail.js
+++ b/src/public/gt3/ride-detail.js
@@ -42,8 +42,10 @@ const WEATHER_EMOJI = {
 function weatherEmoji(condition) {
   if (!condition) return '';
   const lower = condition.toLowerCase();
-  for (const [key, emoji] of Object.entries(WEATHER_EMOJI)) {
-    if (lower.includes(key)) return emoji;
+  if (WEATHER_EMOJI[lower]) return WEATHER_EMOJI[lower];
+  const sortedKeys = Object.keys(WEATHER_EMOJI).sort((a, b) => b.length - a.length);
+  for (const key of sortedKeys) {
+    if (lower.includes(key)) return WEATHER_EMOJI[key];
   }
   return '🌡️';
 }
@@ -185,37 +187,29 @@ async function loadRide() {
     const ws = document.getElementById('weather-section');
     ws.style.display = '';
     const emoji = weatherEmoji(ride.weather_condition);
-    document.getElementById('weather-detail').innerHTML = `
-      <div class="stat-card">
-        <div class="stat-value">${emoji} ${ride.weather_temp.toFixed(0)}°C</div>
-        <div class="stat-label">${ride.weather_condition || 'Temperature'}</div>
-      </div>
-      ${ride.weather_feels_like != null ? `
-      <div class="stat-card">
-        <div class="stat-value">${ride.weather_feels_like.toFixed(0)}°C</div>
-        <div class="stat-label">Feels Like</div>
-      </div>` : ''}
-      ${ride.weather_humidity != null ? `
-      <div class="stat-card">
-        <div class="stat-value">${ride.weather_humidity.toFixed(0)}%</div>
-        <div class="stat-label">Humidity</div>
-      </div>` : ''}
-      ${ride.weather_wind_speed != null ? `
-      <div class="stat-card">
-        <div class="stat-value">${ride.weather_wind_speed.toFixed(0)} km/h</div>
-        <div class="stat-label">Wind</div>
-      </div>` : ''}
-      ${ride.weather_uv_index != null ? `
-      <div class="stat-card">
-        <div class="stat-value">${ride.weather_uv_index.toFixed(0)}</div>
-        <div class="stat-label">UV Index</div>
-      </div>` : ''}
-      ${ride.weather_pressure != null ? `
-      <div class="stat-card">
-        <div class="stat-value">${ride.weather_pressure.toFixed(0)} hPa</div>
-        <div class="stat-label">Pressure</div>
-      </div>` : ''}
-    `;
+    const wd = document.getElementById('weather-detail');
+    wd.innerHTML = '';
+
+    function addStatCard(value, label) {
+      const card = document.createElement('div');
+      card.className = 'stat-card';
+      const valEl = document.createElement('div');
+      valEl.className = 'stat-value';
+      valEl.textContent = value;
+      const labEl = document.createElement('div');
+      labEl.className = 'stat-label';
+      labEl.textContent = label;
+      card.appendChild(valEl);
+      card.appendChild(labEl);
+      wd.appendChild(card);
+    }
+
+    addStatCard(`${emoji} ${ride.weather_temp.toFixed(0)}°C`, ride.weather_condition || 'Temperature');
+    if (ride.weather_feels_like != null) addStatCard(`${ride.weather_feels_like.toFixed(0)}°C`, 'Feels Like');
+    if (ride.weather_humidity != null) addStatCard(`${ride.weather_humidity.toFixed(0)}%`, 'Humidity');
+    if (ride.weather_wind_speed != null) addStatCard(`${ride.weather_wind_speed.toFixed(0)} km/h`, 'Wind');
+    if (ride.weather_uv_index != null) addStatCard(`${ride.weather_uv_index.toFixed(0)}`, 'UV Index');
+    if (ride.weather_pressure != null) addStatCard(`${ride.weather_pressure.toFixed(0)} hPa`, 'Pressure');
   }
 
   // ── Map ─────────────────────────────────────────────────

--- a/src/public/gt3/ride-detail.js
+++ b/src/public/gt3/ride-detail.js
@@ -22,9 +22,30 @@ Chart.defaults.color = CHART_COLORS.subtext;
 Chart.defaults.borderColor = CHART_COLORS.surface;
 
 const GEAR_NAMES = { 1: 'Eco', 2: 'Standard', 3: 'Sport', 4: 'Race' };
+const GEAR_COLORS = { 1: '#a6e3a1', 2: '#89b4fa', 3: '#fab387', 4: '#f38ba8' };
 function gearName(mode) {
   if (mode == null) return 'Unknown';
   return GEAR_NAMES[mode] || `Mode ${mode}`;
+}
+
+const WEATHER_EMOJI = {
+  clear: '☀️', sunny: '☀️',
+  'mostly clear': '🌤️', 'partly cloudy': '⛅',
+  cloudy: '☁️', overcast: '☁️', 'mostly cloudy': '🌥️',
+  rain: '🌧️', drizzle: '🌦️', showers: '🌦️', 'heavy rain': '🌧️',
+  thunderstorm: '⛈️', 'thunderstorms': '⛈️',
+  snow: '🌨️', sleet: '🌨️', 'freezing rain': '🌨️',
+  fog: '🌫️', haze: '🌫️', mist: '🌫️',
+  wind: '💨', windy: '💨', breezy: '💨',
+};
+
+function weatherEmoji(condition) {
+  if (!condition) return '';
+  const lower = condition.toLowerCase();
+  for (const [key, emoji] of Object.entries(WEATHER_EMOJI)) {
+    if (lower.includes(key)) return emoji;
+  }
+  return '🌡️';
 }
 
 // ── Helpers ────────────────────────────────────────────────
@@ -139,7 +160,7 @@ async function loadRide() {
     </div>
     <div class="stat-card">
       <div class="stat-value">${ride.distance != null ? ride.distance.toFixed(1) + ' km' : '—'}</div>
-      <div class="stat-label">Distance</div>
+      <div class="stat-label">Distance${ride.gps_distance != null ? ' (GPS)' : ''}</div>
     </div>
     <div class="stat-card">
       <div class="stat-value">${ride.max_speed != null ? ride.max_speed.toFixed(1) + ' km/h' : '—'}</div>
@@ -163,9 +184,10 @@ async function loadRide() {
   if (ride.weather_temp != null) {
     const ws = document.getElementById('weather-section');
     ws.style.display = '';
+    const emoji = weatherEmoji(ride.weather_condition);
     document.getElementById('weather-detail').innerHTML = `
       <div class="stat-card">
-        <div class="stat-value">${ride.weather_temp.toFixed(0)}°C</div>
+        <div class="stat-value">${emoji} ${ride.weather_temp.toFixed(0)}°C</div>
         <div class="stat-label">${ride.weather_condition || 'Temperature'}</div>
       </div>
       ${ride.weather_feels_like != null ? `
@@ -389,6 +411,38 @@ async function loadRide() {
       });
     } else {
       hideCard('roughnessChart');
+    }
+
+    // Gear mode breakdown — count samples per gear mode
+    const gearCounts = {};
+    samples.forEach(s => {
+      const mode = parseInt(s.gear_mode || s.gearMode) || 0;
+      if (mode > 0) gearCounts[mode] = (gearCounts[mode] || 0) + 1;
+    });
+    const gearModes = Object.keys(gearCounts).map(Number).sort();
+    if (gearModes.length > 0) {
+      const total = gearModes.reduce((sum, m) => sum + gearCounts[m], 0);
+      const gearSection = document.getElementById('gear-breakdown');
+      if (gearSection) {
+        gearSection.style.display = '';
+        gearSection.innerHTML = `
+          <h3>Gear Mode Breakdown</h3>
+          <div class="gear-bar" style="display:flex;border-radius:8px;overflow:hidden;height:32px;margin-bottom:1rem">
+            ${gearModes.map(m => {
+              const pct = (gearCounts[m] / total * 100).toFixed(1);
+              const color = GEAR_COLORS[m] || CHART_COLORS.overlay;
+              return `<div style="width:${pct}%;background:${color};display:flex;align-items:center;justify-content:center;font-size:0.75rem;color:#1e1e2e;font-weight:600" title="${gearName(m)}: ${pct}%">${pct > 8 ? gearName(m) : ''}</div>`;
+            }).join('')}
+          </div>
+          <div style="display:flex;gap:1.5rem;flex-wrap:wrap">
+            ${gearModes.map(m => {
+              const pct = (gearCounts[m] / total * 100).toFixed(1);
+              const color = GEAR_COLORS[m] || CHART_COLORS.overlay;
+              return `<span style="display:flex;align-items:center;gap:0.4rem"><span style="width:12px;height:12px;border-radius:50%;background:${color};display:inline-block"></span>${gearName(m)}: ${pct}%</span>`;
+            }).join('')}
+          </div>
+        `;
+      }
     }
 
     // GPX export button

--- a/src/public/gt3/ride.html
+++ b/src/public/gt3/ride.html
@@ -58,6 +58,9 @@
             </div>
         </section>
 
+        <section id="gear-breakdown" class="card" style="display:none; padding: 1.5rem;">
+        </section>
+
         <section class="card" style="text-align:center; padding: 1.5rem;">
             <button id="gpx-export" style="display:none;">📥 Export GPX</button>
         </section>

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -38,7 +38,7 @@ function gpsDistanceFromTrack(track: number[][]): number {
   for (let i = 1; i < track.length; i++) {
     const [lon1, lat1] = track[i - 1];
     const [lon2, lat2] = track[i];
-    if (lat1 && lon1 && lat2 && lon2) {
+    if (Number.isFinite(lat1) && Number.isFinite(lon1) && Number.isFinite(lat2) && Number.isFinite(lon2)) {
       total += haversineKm(lat1, lon1, lat2, lon2);
     }
   }
@@ -307,7 +307,7 @@ router.get('/rides', async (req, res) => {
         battery_used, start_battery, end_battery, gear_mode, health_data, metadata,
         weather_temp, weather_feels_like, weather_humidity, weather_wind_speed,
         weather_wind_direction, weather_condition, weather_uv_index, weather_pressure,
-        gps_track, created_at
+        CASE WHEN distance IS NULL OR distance < 0.5 THEN gps_track ELSE NULL END AS gps_track, created_at
        FROM gt3_rides WHERE user_sub = $1
        ORDER BY start_time DESC LIMIT $2 OFFSET $3`,
       [userSub, limit, offset],
@@ -318,13 +318,13 @@ router.get('/rides', async (req, res) => {
       const gpsDistance = track && Array.isArray(track) && track.length > 1
         ? gpsDistanceFromTrack(track) : null;
       // Prefer GPS distance when the stored distance looks wrong (< 0.5 km)
-      const bestDistance = gpsDistance && (
-        !r.distance || (r.distance as number) < 0.5
+      const bestDistance = gpsDistance != null && (
+        r.distance == null || (r.distance as number) < 0.5
       ) ? gpsDistance : r.distance as number;
       return {
         ...r,
         gps_track: undefined, // Don't send full track in list response
-        gps_distance: gpsDistance ? parseFloat(gpsDistance.toFixed(2)) : null,
+        gps_distance: gpsDistance != null ? parseFloat(gpsDistance.toFixed(2)) : null,
         distance: bestDistance != null ? parseFloat((bestDistance as number).toFixed(2)) : null,
       };
     });

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -17,6 +17,34 @@ const gt3Logger = logger.child({ subsystem: 'gt3' });
 
 const router = Router();
 
+// ── Helpers ────────────────────────────────────────────────
+
+/** Haversine distance between two coordinates in km. */
+function haversineKm(
+  lat1: number, lon1: number, lat2: number, lon2: number,
+): number {
+  const R = 6371;
+  const dLat = (lat2 - lat1) * Math.PI / 180;
+  const dLon = (lon2 - lon1) * Math.PI / 180;
+  const a = Math.sin(dLat / 2) ** 2
+    + Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180)
+    * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+/** Compute total GPS distance from a GeoJSON-style coordinate array [[lon,lat,alt?],...]. */
+function gpsDistanceFromTrack(track: number[][]): number {
+  let total = 0;
+  for (let i = 1; i < track.length; i++) {
+    const [lon1, lat1] = track[i - 1];
+    const [lon2, lat2] = track[i];
+    if (lat1 && lon1 && lat2 && lon2) {
+      total += haversineKm(lat1, lon1, lat2, lon2);
+    }
+  }
+  return total;
+}
+
 // POST /gt3/telemetry — batch telemetry samples → InfluxDB
 router.post('/telemetry', async (req, res) => {
   try {
@@ -279,12 +307,28 @@ router.get('/rides', async (req, res) => {
         battery_used, start_battery, end_battery, gear_mode, health_data, metadata,
         weather_temp, weather_feels_like, weather_humidity, weather_wind_speed,
         weather_wind_direction, weather_condition, weather_uv_index, weather_pressure,
-        created_at
+        gps_track, created_at
        FROM gt3_rides WHERE user_sub = $1
        ORDER BY start_time DESC LIMIT $2 OFFSET $3`,
       [userSub, limit, offset],
     );
-    return res.json({ rides: result.rows, page, limit });
+    // Compute GPS distance for rides that have a GPS track
+    const rides = result.rows.map((r: Record<string, unknown>) => {
+      const track = r.gps_track as number[][] | null;
+      const gpsDistance = track && Array.isArray(track) && track.length > 1
+        ? gpsDistanceFromTrack(track) : null;
+      // Prefer GPS distance when the stored distance looks wrong (< 0.5 km)
+      const bestDistance = gpsDistance && (
+        !r.distance || (r.distance as number) < 0.5
+      ) ? gpsDistance : r.distance as number;
+      return {
+        ...r,
+        gps_track: undefined, // Don't send full track in list response
+        gps_distance: gpsDistance ? parseFloat(gpsDistance.toFixed(2)) : null,
+        distance: bestDistance != null ? parseFloat((bestDistance as number).toFixed(2)) : null,
+      };
+    });
+    return res.json({ rides, page, limit });
   } catch (err) {
     gt3Logger.error({ err }, 'Failed to list rides');
     return res.status(500).json({ error: 'Internal server error' });
@@ -302,7 +346,17 @@ router.get('/rides/:id', async (req, res) => {
       [req.params.id, userSub],
     );
     if (result.rows.length === 0) return res.status(404).json({ error: 'Ride not found' });
-    return res.json(result.rows[0]);
+    const ride = result.rows[0];
+    // Compute GPS distance from track if available
+    const track = ride.gps_track;
+    if (track && Array.isArray(track) && track.length > 1) {
+      ride.gps_distance = parseFloat(gpsDistanceFromTrack(track).toFixed(2));
+      // Replace bad scooter distance with GPS distance
+      if (!ride.distance || ride.distance < 0.5) {
+        ride.distance = ride.gps_distance;
+      }
+    }
+    return res.json(ride);
   } catch (err) {
     gt3Logger.error({ err }, 'Failed to get ride');
     return res.status(500).json({ error: 'Internal server error' });

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -20,14 +20,12 @@ const router = Router();
 // ── Helpers ────────────────────────────────────────────────
 
 /** Haversine distance between two coordinates in km. */
-function haversineKm(
-  lat1: number, lon1: number, lat2: number, lon2: number,
-): number {
+function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
   const R = 6371;
-  const dLat = (lat2 - lat1) * Math.PI / 180;
-  const dLon = (lon2 - lon1) * Math.PI / 180;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
   const a = Math.sin(dLat / 2) ** 2
-    + Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180)
+    + Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180)
     * Math.sin(dLon / 2) ** 2;
   return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 }
@@ -35,7 +33,7 @@ function haversineKm(
 /** Compute total GPS distance from a GeoJSON-style coordinate array [[lon,lat,alt?],...]. */
 function gpsDistanceFromTrack(track: number[][]): number {
   let total = 0;
-  for (let i = 1; i < track.length; i++) {
+  for (let i = 1; i < track.length; i += 1) {
     const [lon1, lat1] = track[i - 1];
     const [lon2, lat2] = track[i];
     if (Number.isFinite(lat1) && Number.isFinite(lon1) && Number.isFinite(lat2) && Number.isFinite(lon2)) {


### PR DESCRIPTION
## Changes

### GPS Distance Computation
- Added server-side haversine helper to compute accurate distance from `gps_track` JSONB
- Ride list and detail APIs now return `gps_distance` and prefer GPS over scooter register when stored distance < 0.5 km
- Distance label on ride detail shows "(GPS)" when GPS-computed

### Weather Emoji
- Added weather condition → emoji mapping (☀️ Clear, 🌧️ Rain, ⛈️ Thunderstorm, etc.)
- Dashboard ride list shows emoji + temperature instead of just temperature
- Ride detail weather section shows emoji next to temperature

### Gear Mode Breakdown
- Ride detail page now shows a color-coded bar chart of time spent in each gear mode
- Computed from telemetry samples: Eco (green), Standard (blue), Sport (orange), Race (red)
- Legend shows percentage for each mode

Fixes the same distance bug that was fixed app-side in gt3pro PR #107.