### PR TITLE
feat(gt3): shareable ride links with optional expiry

### DIFF
--- a/src/__tests__/gt3-share.test.ts
+++ b/src/__tests__/gt3-share.test.ts
@@ -1,0 +1,281 @@
+import request from 'supertest';
+import express from 'express';
+import gt3Router from '../routes/gt3.routes';
+import gt3PublicRouter from '../routes/gt3-public.routes';
+
+jest.mock('../logger', () => ({
+  __esModule: true,
+  default: {
+    child: () => ({
+      info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+    }),
+  },
+}));
+
+jest.mock('../db', () => ({
+  getPool: jest.fn(),
+}));
+
+jest.mock('../influx', () => ({ writePoint: jest.fn() }));
+jest.mock('../clients/influxdb', () => ({
+  InfluxDBClient: jest.fn().mockImplementation(() => ({ configured: false, query: jest.fn() })),
+}));
+jest.mock('../apns', () => ({ sendGT3PushToStart: jest.fn() }));
+jest.mock('../push-token-store', () => ({ getDeviceTokensByUserAndBundle: jest.fn() }));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+const { getPool } = require('../db');
+
+const USER_SUB = 'owner-sub';
+const OTHER_SUB = 'stranger-sub';
+const RIDE_ID = '11111111-1111-1111-1111-111111111111';
+
+function buildApp(userSub: string | null) {
+  const app = express();
+  app.use(express.json());
+  // Public router mounts first (no auth)
+  app.use('/gt3', gt3PublicRouter);
+  // Then simulated auth
+  app.use('/gt3', (req, _res, next) => {
+    if (userSub) req.user = { sub: userSub, role: 'admin', username: 'u' };
+    next();
+  }, gt3Router);
+  return app;
+}
+
+describe('GT3 ride share links', () => {
+  let mockQuery: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQuery = jest.fn();
+    (getPool as jest.Mock).mockReturnValue({ query: mockQuery, connect: jest.fn() });
+  });
+
+  describe('POST /gt3/rides/:id/shares', () => {
+    it('creates a share with a preset expiresIn', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: RIDE_ID }] }) // ownership check
+        .mockResolvedValueOnce({
+          rows: [{ token: 'abc', expires_at: new Date(Date.now() + 3600_000), created_at: new Date() }],
+        });
+
+      const app = buildApp(USER_SUB);
+      const res = await request(app)
+        .post(`/gt3/rides/${RIDE_ID}/shares`)
+        .send({ expiresIn: '1h' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.token).toBe('abc');
+      expect(res.body.status).toBe('active');
+      expect(res.body.expiresAt).toBeTruthy();
+      // second call inserts with a non-null expires_at
+      const insertArgs = mockQuery.mock.calls[1][1];
+      expect(insertArgs[1]).toBe(RIDE_ID);
+      expect(insertArgs[2]).toBe(USER_SUB);
+      expect(insertArgs[3]).toBeInstanceOf(Date);
+    });
+
+    it('creates a never-expiring share', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: RIDE_ID }] })
+        .mockResolvedValueOnce({
+          rows: [{ token: 'neverToken', expires_at: null, created_at: new Date() }],
+        });
+
+      const res = await request(buildApp(USER_SUB))
+        .post(`/gt3/rides/${RIDE_ID}/shares`)
+        .send({ expiresIn: 'never' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.expiresAt).toBeNull();
+      expect(mockQuery.mock.calls[1][1][3]).toBeNull();
+    });
+
+    it('accepts a custom expiresAt ISO string', async () => {
+      const future = new Date(Date.now() + 5 * 24 * 3600_000).toISOString();
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: RIDE_ID }] })
+        .mockResolvedValueOnce({
+          rows: [{ token: 'custToken', expires_at: new Date(future), created_at: new Date() }],
+        });
+
+      const res = await request(buildApp(USER_SUB))
+        .post(`/gt3/rides/${RIDE_ID}/shares`)
+        .send({ expiresAt: future });
+
+      expect(res.status).toBe(200);
+      expect(res.body.token).toBe('custToken');
+    });
+
+    it('rejects past expiresAt', async () => {
+      const res = await request(buildApp(USER_SUB))
+        .post(`/gt3/rides/${RIDE_ID}/shares`)
+        .send({ expiresAt: new Date(Date.now() - 1000).toISOString() });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 404 when the ride does not belong to the user', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      const res = await request(buildApp(OTHER_SUB))
+        .post(`/gt3/rides/${RIDE_ID}/shares`)
+        .send({ expiresIn: '24h' });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /gt3/rides/:id/shares', () => {
+    it('returns shares with computed status', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: RIDE_ID }] })
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              token: 't-active',
+              expires_at: new Date(Date.now() + 3600_000),
+              revoked_at: null,
+              created_at: new Date(),
+              last_accessed_at: null,
+              access_count: 0,
+            },
+            {
+              token: 't-expired',
+              expires_at: new Date(Date.now() - 3600_000),
+              revoked_at: null,
+              created_at: new Date(),
+              last_accessed_at: null,
+              access_count: 3,
+            },
+            {
+              token: 't-revoked',
+              expires_at: null,
+              revoked_at: new Date(),
+              created_at: new Date(),
+              last_accessed_at: null,
+              access_count: 1,
+            },
+          ],
+        });
+
+      const res = await request(buildApp(USER_SUB)).get(`/gt3/rides/${RIDE_ID}/shares`);
+      expect(res.status).toBe(200);
+      const statuses = res.body.shares.map((s: { status: string }) => s.status);
+      expect(statuses).toEqual(['active', 'expired', 'revoked']);
+    });
+  });
+
+  describe('DELETE /gt3/rides/:id/shares/:token', () => {
+    it('revokes a share', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ token: 'abc' }] });
+      const res = await request(buildApp(USER_SUB))
+        .delete(`/gt3/rides/${RIDE_ID}/shares/abc`);
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+
+    it('returns 404 if share does not exist / not owned', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      const res = await request(buildApp(USER_SUB))
+        .delete(`/gt3/rides/${RIDE_ID}/shares/unknown`);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /gt3/shared/:token (public)', () => {
+    it('returns ride data for a valid share token', async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{
+            token: 'tok', ride_id: RIDE_ID, expires_at: null, revoked_at: null,
+          }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{
+            id: RIDE_ID,
+            start_time: new Date(),
+            end_time: null,
+            distance: 10,
+            max_speed: 40,
+            avg_speed: 20,
+            battery_used: 5,
+            start_battery: 100,
+            end_battery: 95,
+            gear_mode: 2,
+            gps_track: null,
+            health_data: null,
+            metadata: null,
+            weather_temp: null,
+            weather_feels_like: null,
+            weather_humidity: null,
+            weather_wind_speed: null,
+            weather_wind_direction: null,
+            weather_condition: null,
+            weather_uv_index: null,
+            weather_pressure: null,
+            created_at: new Date(),
+          }],
+        })
+        .mockResolvedValueOnce({ rows: [] }); // bumpAccess (fire-and-forget)
+
+      // No auth — anonymous request
+      const res = await request(buildApp(null)).get('/gt3/shared/tok');
+      expect(res.status).toBe(200);
+      expect(res.body.ride.id).toBe(RIDE_ID);
+      expect(res.body.share.token).toBe('tok');
+      // user_sub must never be exposed
+      expect(res.body.ride.user_sub).toBeUndefined();
+    });
+
+    it('returns 404 for unknown/expired/revoked tokens', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      const res = await request(buildApp(null)).get('/gt3/shared/nope');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /gt3/shared/:token/samples (public)', () => {
+    it('returns samples for a valid share token', async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{
+            token: 'tok', ride_id: RIDE_ID, expires_at: null, revoked_at: null,
+          }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{
+            timestamp: new Date(),
+            speed: 30,
+            battery: 90,
+            bms_voltage: 0,
+            bms_current: 0,
+            bms_soc: 0,
+            bms_temp: 0,
+            body_temp: 0,
+            gear_mode: 2,
+            trip_distance: 0,
+            trip_time: 0,
+            range_estimate: 0,
+            error_code: 0,
+            warn_code: 0,
+            regen_level: 0,
+            speed_response: 0,
+            latitude: 0,
+            longitude: 0,
+            altitude: 0,
+            gps_speed: 0,
+            gps_course: 0,
+            horizontal_accuracy: 0,
+            roughness_score: 0,
+            max_acceleration: 0,
+            heart_rate: 120,
+          }],
+        })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(buildApp(null)).get('/gt3/shared/tok/samples');
+      expect(res.status).toBe(200);
+      expect(res.body.samples).toHaveLength(1);
+      expect(res.body.samples[0].heart_rate).toBe(120);
+    });
+  });
+});

--- a/src/__tests__/gt3-share.test.ts
+++ b/src/__tests__/gt3-share.test.ts
@@ -54,10 +54,11 @@ describe('GT3 ride share links', () => {
 
   describe('POST /gt3/rides/:id/shares', () => {
     it('creates a share with a preset expiresIn', async () => {
+      const SHARE_ID = '22222222-2222-2222-2222-222222222222';
       mockQuery
         .mockResolvedValueOnce({ rows: [{ id: RIDE_ID }] }) // ownership check
         .mockResolvedValueOnce({
-          rows: [{ token: 'abc', expires_at: new Date(Date.now() + 3600_000), created_at: new Date() }],
+          rows: [{ id: SHARE_ID, expires_at: new Date(Date.now() + 3600_000), created_at: new Date() }],
         });
 
       const app = buildApp(USER_SUB);
@@ -66,11 +67,15 @@ describe('GT3 ride share links', () => {
         .send({ expiresIn: '1h' });
 
       expect(res.status).toBe(200);
-      expect(res.body.token).toBe('abc');
+      expect(res.body.id).toBe(SHARE_ID);
+      expect(typeof res.body.token).toBe('string');
+      expect(res.body.token.length).toBeGreaterThan(20);
       expect(res.body.status).toBe('active');
       expect(res.body.expiresAt).toBeTruthy();
-      // second call inserts with a non-null expires_at
+      // second call inserts (tokenHash, ride_id, userSub, expires_at)
       const insertArgs = mockQuery.mock.calls[1][1];
+      expect(typeof insertArgs[0]).toBe('string'); // token_hash
+      expect(insertArgs[0]).toHaveLength(64); // sha256 hex
       expect(insertArgs[1]).toBe(RIDE_ID);
       expect(insertArgs[2]).toBe(USER_SUB);
       expect(insertArgs[3]).toBeInstanceOf(Date);
@@ -80,7 +85,7 @@ describe('GT3 ride share links', () => {
       mockQuery
         .mockResolvedValueOnce({ rows: [{ id: RIDE_ID }] })
         .mockResolvedValueOnce({
-          rows: [{ token: 'neverToken', expires_at: null, created_at: new Date() }],
+          rows: [{ id: 'sid', expires_at: null, created_at: new Date() }],
         });
 
       const res = await request(buildApp(USER_SUB))
@@ -97,7 +102,7 @@ describe('GT3 ride share links', () => {
       mockQuery
         .mockResolvedValueOnce({ rows: [{ id: RIDE_ID }] })
         .mockResolvedValueOnce({
-          rows: [{ token: 'custToken', expires_at: new Date(future), created_at: new Date() }],
+          rows: [{ id: 'sid', expires_at: new Date(future), created_at: new Date() }],
         });
 
       const res = await request(buildApp(USER_SUB))
@@ -105,7 +110,7 @@ describe('GT3 ride share links', () => {
         .send({ expiresAt: future });
 
       expect(res.status).toBe(200);
-      expect(res.body.token).toBe('custToken');
+      expect(typeof res.body.token).toBe('string');
     });
 
     it('rejects past expiresAt', async () => {
@@ -113,6 +118,41 @@ describe('GT3 ride share links', () => {
         .post(`/gt3/rides/${RIDE_ID}/shares`)
         .send({ expiresAt: new Date(Date.now() - 1000).toISOString() });
       expect(res.status).toBe(400);
+    });
+
+    it('rejects when both expiresIn and expiresAt are provided', async () => {
+      const res = await request(buildApp(USER_SUB))
+        .post(`/gt3/rides/${RIDE_ID}/shares`)
+        .send({ expiresIn: '1h', expiresAt: new Date(Date.now() + 3600_000).toISOString() });
+      expect(res.status).toBe(400);
+      // ownership check must not even run
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it('rejects when neither expiresIn nor expiresAt is provided', async () => {
+      const res = await request(buildApp(USER_SUB))
+        .post(`/gt3/rides/${RIDE_ID}/shares`)
+        .send({});
+      expect(res.status).toBe(400);
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it('retries on unique-hash collision', async () => {
+      const collision = Object.assign(new Error('dup'), { code: '23505' });
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: RIDE_ID }] }) // ownership
+        .mockRejectedValueOnce(collision) // first insert collides
+        .mockResolvedValueOnce({
+          rows: [{ id: 'sid', expires_at: null, created_at: new Date() }],
+        });
+
+      const res = await request(buildApp(USER_SUB))
+        .post(`/gt3/rides/${RIDE_ID}/shares`)
+        .send({ expiresIn: 'never' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe('sid');
+      expect(mockQuery).toHaveBeenCalledTimes(3);
     });
 
     it('returns 404 when the ride does not belong to the user', async () => {
@@ -131,7 +171,7 @@ describe('GT3 ride share links', () => {
         .mockResolvedValueOnce({
           rows: [
             {
-              token: 't-active',
+              id: 's-active',
               expires_at: new Date(Date.now() + 3600_000),
               revoked_at: null,
               created_at: new Date(),
@@ -139,7 +179,7 @@ describe('GT3 ride share links', () => {
               access_count: 0,
             },
             {
-              token: 't-expired',
+              id: 's-expired',
               expires_at: new Date(Date.now() - 3600_000),
               revoked_at: null,
               created_at: new Date(),
@@ -147,7 +187,7 @@ describe('GT3 ride share links', () => {
               access_count: 3,
             },
             {
-              token: 't-revoked',
+              id: 's-revoked',
               expires_at: null,
               revoked_at: new Date(),
               created_at: new Date(),
@@ -161,32 +201,38 @@ describe('GT3 ride share links', () => {
       expect(res.status).toBe(200);
       const statuses = res.body.shares.map((s: { status: string }) => s.status);
       expect(statuses).toEqual(['active', 'expired', 'revoked']);
+      expect(res.body.shares[0].id).toBe('s-active');
+      // Raw token must never appear in listings
+      expect(res.body.shares[0].token).toBeUndefined();
     });
   });
 
-  describe('DELETE /gt3/rides/:id/shares/:token', () => {
-    it('revokes a share', async () => {
-      mockQuery.mockResolvedValueOnce({ rows: [{ token: 'abc' }] });
+  describe('DELETE /gt3/rides/:id/shares/:shareId', () => {
+    it('revokes a share by id', async () => {
+      const SHARE_ID = '33333333-3333-3333-3333-333333333333';
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: SHARE_ID }] });
       const res = await request(buildApp(USER_SUB))
-        .delete(`/gt3/rides/${RIDE_ID}/shares/abc`);
+        .delete(`/gt3/rides/${RIDE_ID}/shares/${SHARE_ID}`);
       expect(res.status).toBe(200);
       expect(res.body.ok).toBe(true);
+      expect(mockQuery.mock.calls[0][1]).toEqual([SHARE_ID, RIDE_ID, USER_SUB]);
     });
 
     it('returns 404 if share does not exist / not owned', async () => {
       mockQuery.mockResolvedValueOnce({ rows: [] });
       const res = await request(buildApp(USER_SUB))
-        .delete(`/gt3/rides/${RIDE_ID}/shares/unknown`);
+        .delete(`/gt3/rides/${RIDE_ID}/shares/44444444-4444-4444-4444-444444444444`);
       expect(res.status).toBe(404);
     });
   });
 
   describe('GET /gt3/shared/:token (public)', () => {
-    it('returns ride data for a valid share token', async () => {
+    it('returns ride data for a valid share token and looks it up by hash', async () => {
+      const SHARE_ID = '55555555-5555-5555-5555-555555555555';
       mockQuery
         .mockResolvedValueOnce({
           rows: [{
-            token: 'tok', ride_id: RIDE_ID, expires_at: null, revoked_at: null,
+            id: SHARE_ID, ride_id: RIDE_ID, expires_at: null, revoked_at: null,
           }],
         })
         .mockResolvedValueOnce({
@@ -218,10 +264,15 @@ describe('GT3 ride share links', () => {
         .mockResolvedValueOnce({ rows: [] }); // bumpAccess (fire-and-forget)
 
       // No auth — anonymous request
-      const res = await request(buildApp(null)).get('/gt3/shared/tok');
+      const res = await request(buildApp(null)).get('/gt3/shared/raw-token-value');
       expect(res.status).toBe(200);
       expect(res.body.ride.id).toBe(RIDE_ID);
-      expect(res.body.share.token).toBe('tok');
+      // Lookup used hashed token, not the raw value
+      const lookupArgs = mockQuery.mock.calls[0][1];
+      expect(lookupArgs[0]).toHaveLength(64);
+      expect(lookupArgs[0]).not.toBe('raw-token-value');
+      // Raw token must never echo back on public responses
+      expect(res.body.share?.token).toBeUndefined();
       // user_sub must never be exposed
       expect(res.body.ride.user_sub).toBeUndefined();
     });
@@ -238,7 +289,7 @@ describe('GT3 ride share links', () => {
       mockQuery
         .mockResolvedValueOnce({
           rows: [{
-            token: 'tok', ride_id: RIDE_ID, expires_at: null, revoked_at: null,
+            id: 'sid', ride_id: RIDE_ID, expires_at: null, revoked_at: null,
           }],
         })
         .mockResolvedValueOnce({

--- a/src/db.ts
+++ b/src/db.ts
@@ -297,6 +297,19 @@ export async function initDatabase(): Promise<void> {
         heart_rate INTEGER
       );
       CREATE INDEX IF NOT EXISTS idx_gt3_samples_ride ON gt3_samples (ride_id, timestamp);
+
+      CREATE TABLE IF NOT EXISTS gt3_ride_shares (
+        token TEXT PRIMARY KEY,
+        ride_id UUID NOT NULL REFERENCES gt3_rides(id) ON DELETE CASCADE,
+        user_sub TEXT NOT NULL,
+        expires_at TIMESTAMPTZ,
+        revoked_at TIMESTAMPTZ,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        last_accessed_at TIMESTAMPTZ,
+        access_count INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE INDEX IF NOT EXISTS idx_gt3_ride_shares_ride ON gt3_ride_shares (ride_id);
+      CREATE INDEX IF NOT EXISTS idx_gt3_ride_shares_user ON gt3_ride_shares (user_sub, created_at DESC);
     `);
     dbLogger.info('Database tables initialized');
   } catch (err) {

--- a/src/db.ts
+++ b/src/db.ts
@@ -299,7 +299,8 @@ export async function initDatabase(): Promise<void> {
       CREATE INDEX IF NOT EXISTS idx_gt3_samples_ride ON gt3_samples (ride_id, timestamp);
 
       CREATE TABLE IF NOT EXISTS gt3_ride_shares (
-        token TEXT PRIMARY KEY,
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        token_hash TEXT NOT NULL UNIQUE,
         ride_id UUID NOT NULL REFERENCES gt3_rides(id) ON DELETE CASCADE,
         user_sub TEXT NOT NULL,
         expires_at TIMESTAMPTZ,

--- a/src/gt3-geo.ts
+++ b/src/gt3-geo.ts
@@ -1,0 +1,23 @@
+/** Haversine distance between two coordinates in km. */
+export function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
+  const a = Math.sin(dLat / 2) ** 2
+    + Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180)
+    * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+/** Compute total GPS distance from a GeoJSON-style coordinate array [[lon,lat,alt?],...]. */
+export function gpsDistanceFromTrack(track: number[][]): number {
+  let total = 0;
+  for (let i = 1; i < track.length; i += 1) {
+    const [lon1, lat1] = track[i - 1];
+    const [lon2, lat2] = track[i];
+    if (Number.isFinite(lat1) && Number.isFinite(lon1) && Number.isFinite(lat2) && Number.isFinite(lon2)) {
+      total += haversineKm(lat1, lon1, lat2, lon2);
+    }
+  }
+  return total;
+}

--- a/src/public/gt3/ride-detail.js
+++ b/src/public/gt3/ride-detail.js
@@ -52,13 +52,51 @@ function weatherEmoji(condition) {
 
 // ── Helpers ────────────────────────────────────────────────
 
+// Detect share-mode (public, no-auth access) via ?share=<token>
+const SHARE_TOKEN = new URLSearchParams(window.location.search).get('share');
+const IS_SHARE_MODE = !!SHARE_TOKEN;
+
+let csrfTokenCache = null;
+async function getCsrf() {
+  if (csrfTokenCache) return csrfTokenCache;
+  try {
+    const res = await fetch('/auth/csrf-token', { credentials: 'include' });
+    if (!res.ok) return null;
+    const data = await res.json();
+    csrfTokenCache = data.csrfToken;
+    return csrfTokenCache;
+  } catch {
+    return null;
+  }
+}
+
 async function apiFetch(path) {
   const res = await fetch(API_BASE + path, { credentials: 'include' });
   if (res.status === 401) {
+    if (IS_SHARE_MODE) return null;
     window.location.href = '/auth/login?redirect=' + encodeURIComponent(window.location.pathname + window.location.search);
     return null;
   }
   if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+async function apiMutate(method, path, body) {
+  const csrf = await getCsrf();
+  const res = await fetch(API_BASE + path, {
+    method,
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(csrf ? { 'X-CSRF-Token': csrf } : {}),
+    },
+    body: body != null ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`API error: ${res.status} ${text}`);
+  }
+  if (res.status === 204) return null;
   return res.json();
 }
 
@@ -136,17 +174,40 @@ ${points.join('\n')}
 async function loadRide() {
   const params = new URLSearchParams(window.location.search);
   const rideId = params.get('id');
-  if (!rideId) {
-    document.querySelector('main').innerHTML =
-      '<p class="error" style="margin:2rem">No ride ID specified. <a href="/gt3/">Return to dashboard</a></p>';
-    return;
-  }
 
-  const [ride, samplesData] = await Promise.all([
-    apiFetch(`/rides/${rideId}`),
-    apiFetch(`/rides/${rideId}/samples`).catch(() => null),
-  ]);
-  if (!ride) return;
+  // Share-mode: fetch from /shared/:token endpoints. Ride id is embedded in response.
+  let ride;
+  let samplesData;
+  let effectiveRideId = rideId;
+  let shareInfo = null;
+
+  if (IS_SHARE_MODE) {
+    const sharedResp = await apiFetch(`/shared/${encodeURIComponent(SHARE_TOKEN)}`);
+    if (!sharedResp || !sharedResp.ride) {
+      document.querySelector('main').innerHTML =
+        '<p class="error" style="margin:2rem">This share link is invalid, expired, or has been revoked.</p>';
+      return;
+    }
+    ride = sharedResp.ride;
+    shareInfo = sharedResp.share;
+    effectiveRideId = ride.id;
+    samplesData = await apiFetch(`/shared/${encodeURIComponent(SHARE_TOKEN)}/samples`).catch(() => null);
+
+    // Hide owner-only navigation ("Back to Dashboard") in share mode
+    const nav = document.querySelector('header nav');
+    if (nav) nav.innerHTML = '<span style="color: var(--subtext0);">Shared ride</span>';
+  } else {
+    if (!rideId) {
+      document.querySelector('main').innerHTML =
+        '<p class="error" style="margin:2rem">No ride ID specified. <a href="/gt3/">Return to dashboard</a></p>';
+      return;
+    }
+    [ride, samplesData] = await Promise.all([
+      apiFetch(`/rides/${rideId}`),
+      apiFetch(`/rides/${rideId}/samples`).catch(() => null),
+    ]);
+    if (!ride) return;
+  }
 
   document.title = `Ride ${formatDate(ride.start_time)} — GT3 Pro`;
 
@@ -449,7 +510,7 @@ async function loadRide() {
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
-        a.download = `gt3-ride-${rideId.slice(0, 8)}.gpx`;
+        a.download = `gt3-ride-${(effectiveRideId || '').slice(0, 8)}.gpx`;
         a.click();
         URL.revokeObjectURL(url);
       };
@@ -458,6 +519,135 @@ async function loadRide() {
     document.querySelectorAll('.charts-grid .card').forEach(card => {
       card.innerHTML = '<p style="color: var(--subtext0); text-align: center; padding: 2rem;">No telemetry data available for this ride</p>';
     });
+  }
+
+  // ── Share banner / Share management UI ──────────────────
+  if (IS_SHARE_MODE) {
+    const banner = document.getElementById('share-banner');
+    if (banner) {
+      const expiryText = shareInfo && shareInfo.expiresAt
+        ? ` · link expires ${formatDate(shareInfo.expiresAt)}`
+        : '';
+      banner.textContent = `🔗 You are viewing a shared ride${expiryText}.`;
+      banner.style.display = '';
+    }
+  } else {
+    initShareManager(effectiveRideId);
+  }
+}
+
+// ── Share management (owner view) ──────────────────────────
+
+function initShareManager(rideId) {
+  const btn = document.getElementById('share-btn');
+  const modal = document.getElementById('share-modal');
+  if (!btn || !modal) return;
+
+  btn.style.display = '';
+
+  const closeBtn = document.getElementById('share-close');
+  const createBtn = document.getElementById('share-create');
+  const expirySelect = document.getElementById('share-expiry');
+  const customInput = document.getElementById('share-expiry-custom');
+  const listEl = document.getElementById('share-list');
+
+  function openModal() {
+    modal.style.display = 'flex';
+    refreshShareList(rideId);
+  }
+  function closeModal() { modal.style.display = 'none'; }
+
+  btn.addEventListener('click', openModal);
+  closeBtn.addEventListener('click', closeModal);
+  modal.addEventListener('click', (e) => { if (e.target === modal) closeModal(); });
+
+  expirySelect.addEventListener('change', () => {
+    customInput.style.display = expirySelect.value === 'custom' ? '' : 'none';
+  });
+
+  createBtn.addEventListener('click', async () => {
+    createBtn.disabled = true;
+    try {
+      const body = {};
+      if (expirySelect.value === 'custom') {
+        if (!customInput.value) {
+          alert('Please pick a custom expiry date/time.');
+          return;
+        }
+        body.expiresAt = new Date(customInput.value).toISOString();
+      } else {
+        body.expiresIn = expirySelect.value;
+      }
+      await apiMutate('POST', `/rides/${rideId}/shares`, body);
+      await refreshShareList(rideId);
+    } catch (err) {
+      alert(`Failed to create share: ${err.message}`);
+    } finally {
+      createBtn.disabled = false;
+    }
+  });
+}
+
+function shareUrlFor(token) {
+  return `${window.location.origin}/gt3/ride.html?share=${encodeURIComponent(token)}`;
+}
+
+async function refreshShareList(rideId) {
+  const listEl = document.getElementById('share-list');
+  if (!listEl) return;
+  listEl.innerHTML = '<p style="color: var(--subtext0);">Loading…</p>';
+  try {
+    const data = await apiFetch(`/rides/${rideId}/shares`);
+    const shares = (data && data.shares) || [];
+    if (shares.length === 0) {
+      listEl.innerHTML = '<p style="color: var(--subtext0);">No share links yet.</p>';
+      return;
+    }
+    listEl.innerHTML = '';
+    for (const s of shares) {
+      const row = document.createElement('div');
+      row.className = 'share-row';
+      const url = shareUrlFor(s.token);
+      const expiry = s.expiresAt ? `expires ${formatDate(s.expiresAt)}` : 'never expires';
+      const accessed = s.accessCount ? `${s.accessCount} view${s.accessCount === 1 ? '' : 's'}` : 'no views';
+      row.innerHTML = `
+        <div class="share-row-meta">
+          <span class="share-status share-status-${s.status}">${s.status}</span>
+          <span>${expiry}</span>
+          <span style="color: var(--subtext0);">· ${accessed}</span>
+        </div>
+        <input type="text" class="share-url" readonly value="${url}" />
+        <div class="share-row-actions">
+          <button class="btn-copy">Copy link</button>
+          ${s.status === 'active' ? '<button class="btn-revoke">Revoke</button>' : ''}
+        </div>
+      `;
+      const copyBtn = row.querySelector('.btn-copy');
+      copyBtn.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(url);
+          copyBtn.textContent = 'Copied!';
+          setTimeout(() => { copyBtn.textContent = 'Copy link'; }, 1500);
+        } catch {
+          row.querySelector('.share-url').select();
+        }
+      });
+      const revokeBtn = row.querySelector('.btn-revoke');
+      if (revokeBtn) {
+        revokeBtn.addEventListener('click', async () => {
+          if (!confirm('Revoke this share link? Anyone with the link will lose access.')) return;
+          try {
+            await apiMutate('DELETE', `/rides/${rideId}/shares/${encodeURIComponent(s.token)}`);
+            await refreshShareList(rideId);
+          } catch (err) {
+            alert(`Failed to revoke: ${err.message}`);
+          }
+        });
+      }
+      listEl.appendChild(row);
+    }
+  } catch (err) {
+    listEl.innerHTML = `<p class="error">Failed to load shares: ${err.message}</p>`;
   }
 }
 

--- a/src/public/gt3/ride-detail.js
+++ b/src/public/gt3/ride-detail.js
@@ -70,13 +70,14 @@ async function getCsrf() {
   }
 }
 
-async function apiFetch(path) {
+async function apiFetch(path, opts = {}) {
   const res = await fetch(API_BASE + path, { credentials: 'include' });
   if (res.status === 401) {
     if (IS_SHARE_MODE) return null;
     window.location.href = '/auth/login?redirect=' + encodeURIComponent(window.location.pathname + window.location.search);
     return null;
   }
+  if (res.status === 404 && opts.allow404) return null;
   if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json();
 }
@@ -182,7 +183,7 @@ async function loadRide() {
   let shareInfo = null;
 
   if (IS_SHARE_MODE) {
-    const sharedResp = await apiFetch(`/shared/${encodeURIComponent(SHARE_TOKEN)}`);
+    const sharedResp = await apiFetch(`/shared/${encodeURIComponent(SHARE_TOKEN)}`, { allow404: true });
     if (!sharedResp || !sharedResp.ride) {
       document.querySelector('main').innerHTML =
         '<p class="error" style="margin:2rem">This share link is invalid, expired, or has been revoked.</p>';
@@ -191,7 +192,7 @@ async function loadRide() {
     ride = sharedResp.ride;
     shareInfo = sharedResp.share;
     effectiveRideId = ride.id;
-    samplesData = await apiFetch(`/shared/${encodeURIComponent(SHARE_TOKEN)}/samples`).catch(() => null);
+    samplesData = await apiFetch(`/shared/${encodeURIComponent(SHARE_TOKEN)}/samples`, { allow404: true }).catch(() => null);
 
     // Hide owner-only navigation ("Back to Dashboard") in share mode
     const nav = document.querySelector('header nav');
@@ -552,6 +553,8 @@ function initShareManager(rideId) {
   const listEl = document.getElementById('share-list');
 
   function openModal() {
+    const box = document.getElementById('share-created');
+    if (box) box.style.display = 'none';
     modal.style.display = 'flex';
     refreshShareList(rideId);
   }
@@ -578,7 +581,8 @@ function initShareManager(rideId) {
       } else {
         body.expiresIn = expirySelect.value;
       }
-      await apiMutate('POST', `/rides/${rideId}/shares`, body);
+      const created = await apiMutate('POST', `/rides/${rideId}/shares`, body);
+      showCreatedShare(created);
       await refreshShareList(rideId);
     } catch (err) {
       alert(`Failed to create share: ${err.message}`);
@@ -586,6 +590,30 @@ function initShareManager(rideId) {
       createBtn.disabled = false;
     }
   });
+}
+
+// Display the raw token/URL once after creation. The server does not store
+// the raw token, so this is the only opportunity to copy it.
+function showCreatedShare(created) {
+  if (!created || !created.token) return;
+  const box = document.getElementById('share-created');
+  const urlInput = document.getElementById('share-created-url');
+  if (!box || !urlInput) return;
+  const url = shareUrlFor(created.token);
+  urlInput.value = url;
+  box.style.display = '';
+  const copyBtn = document.getElementById('share-created-copy');
+  if (copyBtn) {
+    copyBtn.onclick = async () => {
+      try {
+        await navigator.clipboard.writeText(url);
+        copyBtn.textContent = 'Copied!';
+        setTimeout(() => { copyBtn.textContent = 'Copy link'; }, 1500);
+      } catch {
+        urlInput.select();
+      }
+    };
+  }
 }
 
 function shareUrlFor(token) {
@@ -607,37 +635,26 @@ async function refreshShareList(rideId) {
     for (const s of shares) {
       const row = document.createElement('div');
       row.className = 'share-row';
-      const url = shareUrlFor(s.token);
+      const created = s.createdAt ? `created ${formatDate(s.createdAt)}` : '';
       const expiry = s.expiresAt ? `expires ${formatDate(s.expiresAt)}` : 'never expires';
       const accessed = s.accessCount ? `${s.accessCount} view${s.accessCount === 1 ? '' : 's'}` : 'no views';
       row.innerHTML = `
         <div class="share-row-meta">
           <span class="share-status share-status-${s.status}">${s.status}</span>
           <span>${expiry}</span>
+          <span style="color: var(--subtext0);">· ${created}</span>
           <span style="color: var(--subtext0);">· ${accessed}</span>
         </div>
-        <input type="text" class="share-url" readonly value="${url}" />
         <div class="share-row-actions">
-          <button class="btn-copy">Copy link</button>
           ${s.status === 'active' ? '<button class="btn-revoke">Revoke</button>' : ''}
         </div>
       `;
-      const copyBtn = row.querySelector('.btn-copy');
-      copyBtn.addEventListener('click', async () => {
-        try {
-          await navigator.clipboard.writeText(url);
-          copyBtn.textContent = 'Copied!';
-          setTimeout(() => { copyBtn.textContent = 'Copy link'; }, 1500);
-        } catch {
-          row.querySelector('.share-url').select();
-        }
-      });
       const revokeBtn = row.querySelector('.btn-revoke');
       if (revokeBtn) {
         revokeBtn.addEventListener('click', async () => {
           if (!confirm('Revoke this share link? Anyone with the link will lose access.')) return;
           try {
-            await apiMutate('DELETE', `/rides/${rideId}/shares/${encodeURIComponent(s.token)}`);
+            await apiMutate('DELETE', `/rides/${rideId}/shares/${encodeURIComponent(s.id)}`);
             await refreshShareList(rideId);
           } catch (err) {
             alert(`Failed to revoke: ${err.message}`);

--- a/src/public/gt3/ride-detail.js
+++ b/src/public/gt3/ride-detail.js
@@ -647,7 +647,11 @@ async function refreshShareList(rideId) {
       listEl.appendChild(row);
     }
   } catch (err) {
-    listEl.innerHTML = `<p class="error">Failed to load shares: ${err.message}</p>`;
+    listEl.innerHTML = '';
+    const p = document.createElement('p');
+    p.className = 'error';
+    p.textContent = `Failed to load shares: ${err.message}`;
+    listEl.appendChild(p);
   }
 }
 

--- a/src/public/gt3/ride.html
+++ b/src/public/gt3/ride.html
@@ -89,6 +89,14 @@
                 </label>
                 <input id="share-expiry-custom" type="datetime-local" style="display:none;" />
                 <button id="share-create" type="button">Create share link</button>
+                <div id="share-created" style="display:none;" class="share-created-box">
+                    <p style="margin: 0 0 0.4rem 0; font-weight: 600;">✅ Share link created</p>
+                    <p style="margin: 0 0 0.5rem 0; font-size: 0.85rem; color: var(--subtext0, #a6adc8);">
+                        Copy this link now — it will not be shown again.
+                    </p>
+                    <input id="share-created-url" type="text" readonly class="share-url" />
+                    <button id="share-created-copy" type="button" style="margin-top: 0.4rem;">Copy link</button>
+                </div>
                 <h4 style="margin-top: 1.5rem;">Existing links</h4>
                 <div id="share-list"></div>
             </div>

--- a/src/public/gt3/ride.html
+++ b/src/public/gt3/ride.html
@@ -14,9 +14,11 @@
         <h1>🛴 GT3 Pro Dashboard</h1>
         <nav>
             <a href="/gt3/">← Back to Dashboard</a>
+            <button id="share-btn" type="button" style="display:none; margin-left: 1rem;">🔗 Share</button>
         </nav>
     </header>
     <main>
+        <div id="share-banner" class="share-banner" style="display:none;"></div>
         <section id="ride-info" class="stats-grid">
             <div class="stat-card"><div class="loading"><div class="spinner"></div></div></div>
         </section>
@@ -65,6 +67,34 @@
             <button id="gpx-export" style="display:none;">📥 Export GPX</button>
         </section>
     </main>
+
+    <!-- Share modal (owner only) -->
+    <div id="share-modal" class="share-modal" style="display:none;">
+        <div class="share-modal-content">
+            <div class="share-modal-header">
+                <h3>Share this ride</h3>
+                <button id="share-close" type="button" aria-label="Close">✕</button>
+            </div>
+            <div class="share-modal-body">
+                <label>
+                    Link expires
+                    <select id="share-expiry">
+                        <option value="1h">In 1 hour</option>
+                        <option value="24h" selected>In 24 hours</option>
+                        <option value="7d">In 7 days</option>
+                        <option value="30d">In 30 days</option>
+                        <option value="custom">Custom date/time…</option>
+                        <option value="never">Never</option>
+                    </select>
+                </label>
+                <input id="share-expiry-custom" type="datetime-local" style="display:none;" />
+                <button id="share-create" type="button">Create share link</button>
+                <h4 style="margin-top: 1.5rem;">Existing links</h4>
+                <div id="share-list"></div>
+            </div>
+        </div>
+    </div>
+
     <script src="/gt3/ride-detail.js"></script>
 </body>
 </html>

--- a/src/public/gt3/style.css
+++ b/src/public/gt3/style.css
@@ -548,3 +548,10 @@ textarea:focus {
   font-size: 0.85rem;
 }
 .share-row-actions .btn-revoke { background: #f38ba8; color: #1e1e2e; }
+.share-created-box {
+  margin-top: 1rem;
+  padding: 0.8rem;
+  border: 1px solid var(--surface1, #45475a);
+  border-radius: 6px;
+  background: var(--surface0, #313244);
+}

--- a/src/public/gt3/style.css
+++ b/src/public/gt3/style.css
@@ -436,3 +436,115 @@ textarea:focus {
     height: 280px;
   }
 }
+
+/* ── Share link UI ─────────────────────────────────────── */
+.share-banner {
+  background: var(--surface1, #313244);
+  color: var(--text, #cdd6f4);
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  margin: 0 0 1rem 0;
+  border-left: 3px solid #89dceb;
+}
+
+#share-btn {
+  background: #89dceb;
+  color: #1e1e2e;
+  border: none;
+  border-radius: 6px;
+  padding: 0.4rem 0.9rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+#share-btn:hover { filter: brightness(0.9); }
+
+.share-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.share-modal-content {
+  background: var(--base, #1e1e2e);
+  color: var(--text, #cdd6f4);
+  border-radius: 10px;
+  max-width: 600px;
+  width: 92%;
+  max-height: 85vh;
+  overflow-y: auto;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
+}
+.share-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--surface0, #313244);
+}
+.share-modal-header h3 { margin: 0; }
+.share-modal-header button {
+  background: transparent;
+  color: var(--text, #cdd6f4);
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+.share-modal-body { padding: 1rem 1.25rem; display: flex; flex-direction: column; gap: 0.6rem; }
+.share-modal-body label { display: flex; flex-direction: column; gap: 0.3rem; }
+.share-modal-body select,
+.share-modal-body input[type="datetime-local"],
+.share-modal-body input[type="text"] {
+  background: var(--surface0, #313244);
+  color: var(--text, #cdd6f4);
+  border: 1px solid var(--surface1, #45475a);
+  border-radius: 6px;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.95rem;
+}
+#share-create {
+  background: #a6e3a1;
+  color: #1e1e2e;
+  border: none;
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  font-weight: 600;
+  margin-top: 0.3rem;
+}
+#share-create:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.share-row {
+  border: 1px solid var(--surface1, #45475a);
+  border-radius: 8px;
+  padding: 0.7rem 0.9rem;
+  margin-bottom: 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.share-row-meta { display: flex; flex-wrap: wrap; gap: 0.6rem; align-items: center; font-size: 0.88rem; }
+.share-status {
+  padding: 0.1rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.share-status-active { background: #a6e3a1; color: #1e1e2e; }
+.share-status-expired { background: #f9e2af; color: #1e1e2e; }
+.share-status-revoked { background: #f38ba8; color: #1e1e2e; }
+.share-url { width: 100%; font-family: monospace; font-size: 0.8rem; }
+.share-row-actions { display: flex; gap: 0.5rem; }
+.share-row-actions button {
+  background: var(--surface1, #45475a);
+  color: var(--text, #cdd6f4);
+  border: none;
+  border-radius: 6px;
+  padding: 0.3rem 0.7rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+.share-row-actions .btn-revoke { background: #f38ba8; color: #1e1e2e; }

--- a/src/routes/gt3-public.routes.ts
+++ b/src/routes/gt3-public.routes.ts
@@ -1,35 +1,19 @@
 import { Router } from 'express';
+import { createHash } from 'crypto';
 import { getPool } from '../db';
 import logger from '../logger';
+import { gpsDistanceFromTrack } from '../gt3-geo';
 
 const gt3PublicLogger = logger.child({ subsystem: 'gt3-public' });
 
 const router = Router();
 
-function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
-  const R = 6371;
-  const dLat = ((lat2 - lat1) * Math.PI) / 180;
-  const dLon = ((lon2 - lon1) * Math.PI) / 180;
-  const a = Math.sin(dLat / 2) ** 2
-    + Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180)
-    * Math.sin(dLon / 2) ** 2;
-  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-}
-
-function gpsDistanceFromTrack(track: number[][]): number {
-  let total = 0;
-  for (let i = 1; i < track.length; i += 1) {
-    const [lon1, lat1] = track[i - 1];
-    const [lon2, lat2] = track[i];
-    if (Number.isFinite(lat1) && Number.isFinite(lon1) && Number.isFinite(lat2) && Number.isFinite(lon2)) {
-      total += haversineKm(lat1, lon1, lat2, lon2);
-    }
-  }
-  return total;
+function hashShareToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
 }
 
 type ShareRow = {
-  token: string;
+  id: string;
   ride_id: string;
   expires_at: Date | null;
   revoked_at: Date | null;
@@ -38,28 +22,30 @@ type ShareRow = {
 async function resolveValidShare(token: string): Promise<ShareRow | null> {
   const pool = getPool();
   if (!pool) return null;
+  if (typeof token !== 'string' || token.length === 0) return null;
+  const tokenHash = hashShareToken(token);
   const result = await pool.query(
-    `SELECT token, ride_id, expires_at, revoked_at
+    `SELECT id, ride_id, expires_at, revoked_at
      FROM gt3_ride_shares
-     WHERE token = $1
+     WHERE token_hash = $1
        AND revoked_at IS NULL
        AND (expires_at IS NULL OR expires_at > NOW())`,
-    [token],
+    [tokenHash],
   );
   return result.rows[0] ?? null;
 }
 
-function bumpAccess(token: string): void {
+function bumpAccess(shareId: string): void {
   const pool = getPool();
   if (!pool) return;
   pool
     .query(
       `UPDATE gt3_ride_shares
        SET access_count = access_count + 1, last_accessed_at = NOW()
-       WHERE token = $1`,
-      [token],
+       WHERE id = $1`,
+      [shareId],
     )
-    .catch((err: unknown) => gt3PublicLogger.warn({ err, token }, 'Failed to bump share access stats'));
+    .catch((err: unknown) => gt3PublicLogger.warn({ err, shareId }, 'Failed to bump share access stats'));
 }
 
 // GET /gt3/shared/:token — public ride detail
@@ -91,12 +77,11 @@ router.get('/shared/:token', async (req, res) => {
       }
     }
 
-    bumpAccess(share.token);
+    bumpAccess(share.id);
     res.setHeader('Cache-Control', 'private, max-age=60');
     return res.json({
       ride,
       share: {
-        token: share.token,
         expiresAt: share.expires_at,
       },
     });
@@ -122,7 +107,7 @@ router.get('/shared/:token/geojson', async (req, res) => {
     const row = result.rows[0];
     if (!row.gps_track) return res.status(404).json({ error: 'No GPS data for this ride' });
 
-    bumpAccess(share.token);
+    bumpAccess(share.id);
     res.setHeader('Cache-Control', 'private, max-age=60');
     return res.json({
       type: 'Feature',
@@ -181,7 +166,7 @@ router.get('/shared/:token/samples', async (req, res) => {
       heart_rate: row.heart_rate,
     }));
 
-    bumpAccess(share.token);
+    bumpAccess(share.id);
     res.setHeader('Cache-Control', 'private, max-age=60');
     return res.json({ samples, rideId: share.ride_id, source: 'postgres' });
   } catch (err) {

--- a/src/routes/gt3-public.routes.ts
+++ b/src/routes/gt3-public.routes.ts
@@ -1,0 +1,193 @@
+import { Router } from 'express';
+import { getPool } from '../db';
+import logger from '../logger';
+
+const gt3PublicLogger = logger.child({ subsystem: 'gt3-public' });
+
+const router = Router();
+
+function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
+  const a = Math.sin(dLat / 2) ** 2
+    + Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180)
+    * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function gpsDistanceFromTrack(track: number[][]): number {
+  let total = 0;
+  for (let i = 1; i < track.length; i += 1) {
+    const [lon1, lat1] = track[i - 1];
+    const [lon2, lat2] = track[i];
+    if (Number.isFinite(lat1) && Number.isFinite(lon1) && Number.isFinite(lat2) && Number.isFinite(lon2)) {
+      total += haversineKm(lat1, lon1, lat2, lon2);
+    }
+  }
+  return total;
+}
+
+type ShareRow = {
+  token: string;
+  ride_id: string;
+  expires_at: Date | null;
+  revoked_at: Date | null;
+};
+
+async function resolveValidShare(token: string): Promise<ShareRow | null> {
+  const pool = getPool();
+  if (!pool) return null;
+  const result = await pool.query(
+    `SELECT token, ride_id, expires_at, revoked_at
+     FROM gt3_ride_shares
+     WHERE token = $1
+       AND revoked_at IS NULL
+       AND (expires_at IS NULL OR expires_at > NOW())`,
+    [token],
+  );
+  return result.rows[0] ?? null;
+}
+
+function bumpAccess(token: string): void {
+  const pool = getPool();
+  if (!pool) return;
+  pool
+    .query(
+      `UPDATE gt3_ride_shares
+       SET access_count = access_count + 1, last_accessed_at = NOW()
+       WHERE token = $1`,
+      [token],
+    )
+    .catch((err: unknown) => gt3PublicLogger.warn({ err, token }, 'Failed to bump share access stats'));
+}
+
+// GET /gt3/shared/:token — public ride detail
+router.get('/shared/:token', async (req, res) => {
+  const pool = getPool();
+  if (!pool) return res.status(503).json({ error: 'Database unavailable' });
+  try {
+    const share = await resolveValidShare(req.params.token);
+    if (!share) return res.status(404).json({ error: 'Share not found or expired' });
+
+    const rideResult = await pool.query(
+      `SELECT id, start_time, end_time, distance, max_speed, avg_speed,
+              battery_used, start_battery, end_battery, gear_mode,
+              gps_track, health_data, metadata,
+              weather_temp, weather_feels_like, weather_humidity, weather_wind_speed,
+              weather_wind_direction, weather_condition, weather_uv_index, weather_pressure,
+              created_at
+       FROM gt3_rides WHERE id = $1`,
+      [share.ride_id],
+    );
+    if (rideResult.rows.length === 0) return res.status(404).json({ error: 'Ride not found' });
+
+    const ride = rideResult.rows[0];
+    const track = ride.gps_track;
+    if (track && Array.isArray(track) && track.length > 1) {
+      ride.gps_distance = parseFloat(gpsDistanceFromTrack(track).toFixed(2));
+      if (!ride.distance || ride.distance < 0.5) {
+        ride.distance = ride.gps_distance;
+      }
+    }
+
+    bumpAccess(share.token);
+    res.setHeader('Cache-Control', 'private, max-age=60');
+    return res.json({
+      ride,
+      share: {
+        token: share.token,
+        expiresAt: share.expires_at,
+      },
+    });
+  } catch (err) {
+    gt3PublicLogger.error({ err }, 'Failed to get shared ride');
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// GET /gt3/shared/:token/geojson — public GeoJSON
+router.get('/shared/:token/geojson', async (req, res) => {
+  const pool = getPool();
+  if (!pool) return res.status(503).json({ error: 'Database unavailable' });
+  try {
+    const share = await resolveValidShare(req.params.token);
+    if (!share) return res.status(404).json({ error: 'Share not found or expired' });
+
+    const result = await pool.query(
+      'SELECT gps_track, distance, max_speed FROM gt3_rides WHERE id = $1',
+      [share.ride_id],
+    );
+    if (result.rows.length === 0) return res.status(404).json({ error: 'Ride not found' });
+    const row = result.rows[0];
+    if (!row.gps_track) return res.status(404).json({ error: 'No GPS data for this ride' });
+
+    bumpAccess(share.token);
+    res.setHeader('Cache-Control', 'private, max-age=60');
+    return res.json({
+      type: 'Feature',
+      geometry: { type: 'LineString', coordinates: row.gps_track },
+      properties: { ride_id: share.ride_id, distance: row.distance, max_speed: row.max_speed },
+    });
+  } catch (err) {
+    gt3PublicLogger.error({ err }, 'Failed to get shared GeoJSON');
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// GET /gt3/shared/:token/samples — public telemetry samples
+router.get('/shared/:token/samples', async (req, res) => {
+  const pool = getPool();
+  if (!pool) return res.status(503).json({ error: 'Database unavailable' });
+  try {
+    const share = await resolveValidShare(req.params.token);
+    if (!share) return res.status(404).json({ error: 'Share not found or expired' });
+
+    const pgSamples = await pool.query(
+      `SELECT timestamp, speed, battery, bms_voltage, bms_current, bms_soc, bms_temp,
+              body_temp, gear_mode, trip_distance, trip_time, range_estimate,
+              error_code, warn_code, regen_level, speed_response,
+              latitude, longitude, altitude, gps_speed, gps_course,
+              horizontal_accuracy, roughness_score, max_acceleration, heart_rate
+       FROM gt3_samples WHERE ride_id = $1 ORDER BY timestamp`,
+      [share.ride_id],
+    );
+
+    const samples = pgSamples.rows.map((row: Record<string, unknown>) => ({
+      _time: row.timestamp,
+      speed: row.speed,
+      battery: row.battery,
+      bms_voltage: row.bms_voltage,
+      bms_current: row.bms_current,
+      bms_soc: row.bms_soc,
+      bms_temp: row.bms_temp,
+      body_temp: row.body_temp,
+      gear_mode: row.gear_mode,
+      trip_distance: row.trip_distance,
+      trip_time: row.trip_time,
+      range_estimate: row.range_estimate,
+      error_code: row.error_code,
+      warn_code: row.warn_code,
+      regen_level: row.regen_level,
+      speed_response: row.speed_response,
+      latitude: row.latitude,
+      longitude: row.longitude,
+      altitude: row.altitude,
+      gps_speed: row.gps_speed,
+      gps_course: row.gps_course,
+      horizontal_accuracy: row.horizontal_accuracy,
+      roughness_score: row.roughness_score,
+      max_acceleration: row.max_acceleration,
+      heart_rate: row.heart_rate,
+    }));
+
+    bumpAccess(share.token);
+    res.setHeader('Cache-Control', 'private, max-age=60');
+    return res.json({ samples, rideId: share.ride_id, source: 'postgres' });
+  } catch (err) {
+    gt3PublicLogger.error({ err }, 'Failed to get shared samples');
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { randomBytes } from 'crypto';
 import { getPool } from '../db';
 import { writePoint } from '../influx';
 import { InfluxDBClient } from '../clients/influxdb';
@@ -580,6 +581,145 @@ router.post('/activity/start', async (req, res) => {
     return res.json({ success: sent > 0, sent, total: tokens.length });
   } catch (err) {
     gt3Logger.error({ err, userSub }, 'Failed to send GT3 push-to-start');
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ── Share links ────────────────────────────────────────────
+
+const EXPIRES_IN_PRESETS: Record<string, number> = {
+  '1h': 60 * 60 * 1000,
+  '24h': 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+  '30d': 30 * 24 * 60 * 60 * 1000,
+};
+
+function generateShareToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+function shareStatus(row: { expires_at: Date | null; revoked_at: Date | null }): 'active' | 'expired' | 'revoked' {
+  if (row.revoked_at) return 'revoked';
+  if (row.expires_at && new Date(row.expires_at).getTime() <= Date.now()) return 'expired';
+  return 'active';
+}
+
+// POST /gt3/rides/:id/shares — create a share link for a ride
+router.post('/rides/:id/shares', async (req, res) => {
+  const pool = getPool();
+  if (!pool) return res.status(503).json({ error: 'Database unavailable' });
+  const userSub = req.user?.sub;
+  if (!userSub) return res.status(401).json({ error: 'Unauthorized' });
+
+  const { expiresIn, expiresAt } = req.body ?? {};
+
+  let expiresAtDate: Date | null = null;
+  if (expiresIn === 'never' || (expiresIn == null && expiresAt == null)) {
+    expiresAtDate = null;
+  } else if (typeof expiresIn === 'string' && EXPIRES_IN_PRESETS[expiresIn] != null) {
+    expiresAtDate = new Date(Date.now() + EXPIRES_IN_PRESETS[expiresIn]);
+  } else if (typeof expiresAt === 'string') {
+    const parsed = new Date(expiresAt);
+    if (Number.isNaN(parsed.getTime())) {
+      return res.status(400).json({ error: 'Invalid expiresAt' });
+    }
+    if (parsed.getTime() <= Date.now()) {
+      return res.status(400).json({ error: 'expiresAt must be in the future' });
+    }
+    expiresAtDate = parsed;
+  } else {
+    return res.status(400).json({ error: 'Invalid expiresIn / expiresAt' });
+  }
+
+  try {
+    const rideCheck = await pool.query(
+      'SELECT id FROM gt3_rides WHERE id = $1 AND user_sub = $2',
+      [req.params.id, userSub],
+    );
+    if (rideCheck.rows.length === 0) {
+      return res.status(404).json({ error: 'Ride not found' });
+    }
+
+    const token = generateShareToken();
+    const result = await pool.query(
+      `INSERT INTO gt3_ride_shares (token, ride_id, user_sub, expires_at)
+       VALUES ($1, $2, $3, $4)
+       RETURNING token, expires_at, created_at`,
+      [token, req.params.id, userSub, expiresAtDate],
+    );
+    const row = result.rows[0];
+    return res.json({
+      token: row.token,
+      expiresAt: row.expires_at,
+      createdAt: row.created_at,
+      status: 'active',
+    });
+  } catch (err) {
+    gt3Logger.error({ err }, 'Failed to create ride share');
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// GET /gt3/rides/:id/shares — list all share links for a ride
+router.get('/rides/:id/shares', async (req, res) => {
+  const pool = getPool();
+  if (!pool) return res.status(503).json({ error: 'Database unavailable' });
+  const userSub = req.user?.sub;
+  if (!userSub) return res.status(401).json({ error: 'Unauthorized' });
+
+  try {
+    const rideCheck = await pool.query(
+      'SELECT id FROM gt3_rides WHERE id = $1 AND user_sub = $2',
+      [req.params.id, userSub],
+    );
+    if (rideCheck.rows.length === 0) {
+      return res.status(404).json({ error: 'Ride not found' });
+    }
+
+    const result = await pool.query(
+      `SELECT token, expires_at, revoked_at, created_at, last_accessed_at, access_count
+       FROM gt3_ride_shares
+       WHERE ride_id = $1 AND user_sub = $2
+       ORDER BY created_at DESC`,
+      [req.params.id, userSub],
+    );
+    const shares = result.rows.map((row: Record<string, unknown>) => ({
+      token: row.token,
+      expiresAt: row.expires_at,
+      revokedAt: row.revoked_at,
+      createdAt: row.created_at,
+      lastAccessedAt: row.last_accessed_at,
+      accessCount: row.access_count,
+      status: shareStatus(row as { expires_at: Date | null; revoked_at: Date | null }),
+    }));
+    return res.json({ shares });
+  } catch (err) {
+    gt3Logger.error({ err }, 'Failed to list ride shares');
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// DELETE /gt3/rides/:id/shares/:token — revoke a share link
+router.delete('/rides/:id/shares/:token', async (req, res) => {
+  const pool = getPool();
+  if (!pool) return res.status(503).json({ error: 'Database unavailable' });
+  const userSub = req.user?.sub;
+  if (!userSub) return res.status(401).json({ error: 'Unauthorized' });
+
+  try {
+    const result = await pool.query(
+      `UPDATE gt3_ride_shares
+       SET revoked_at = NOW()
+       WHERE token = $1 AND ride_id = $2 AND user_sub = $3 AND revoked_at IS NULL
+       RETURNING token`,
+      [req.params.token, req.params.id, userSub],
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Share not found' });
+    }
+    return res.json({ ok: true });
+  } catch (err) {
+    gt3Logger.error({ err }, 'Failed to revoke ride share');
     return res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -1,11 +1,12 @@
 import { Router } from 'express';
-import { randomBytes } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
 import { getPool } from '../db';
 import { writePoint } from '../influx';
 import { InfluxDBClient } from '../clients/influxdb';
 import logger from '../logger';
 import { sendGT3PushToStart } from '../apns';
 import { getDeviceTokensByUserAndBundle } from '../push-token-store';
+import { gpsDistanceFromTrack } from '../gt3-geo';
 
 const influxQuery = new InfluxDBClient({
   url: (process.env.INFLUXDB_URL || '').trim(),
@@ -17,32 +18,6 @@ const influxQuery = new InfluxDBClient({
 const gt3Logger = logger.child({ subsystem: 'gt3' });
 
 const router = Router();
-
-// ── Helpers ────────────────────────────────────────────────
-
-/** Haversine distance between two coordinates in km. */
-function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
-  const R = 6371;
-  const dLat = ((lat2 - lat1) * Math.PI) / 180;
-  const dLon = ((lon2 - lon1) * Math.PI) / 180;
-  const a = Math.sin(dLat / 2) ** 2
-    + Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180)
-    * Math.sin(dLon / 2) ** 2;
-  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-}
-
-/** Compute total GPS distance from a GeoJSON-style coordinate array [[lon,lat,alt?],...]. */
-function gpsDistanceFromTrack(track: number[][]): number {
-  let total = 0;
-  for (let i = 1; i < track.length; i += 1) {
-    const [lon1, lat1] = track[i - 1];
-    const [lon2, lat2] = track[i];
-    if (Number.isFinite(lat1) && Number.isFinite(lon1) && Number.isFinite(lat2) && Number.isFinite(lon2)) {
-      total += haversineKm(lat1, lon1, lat2, lon2);
-    }
-  }
-  return total;
-}
 
 // POST /gt3/telemetry — batch telemetry samples → InfluxDB
 router.post('/telemetry', async (req, res) => {
@@ -598,10 +573,48 @@ function generateShareToken(): string {
   return randomBytes(32).toString('base64url');
 }
 
+function hashShareToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
 function shareStatus(row: { expires_at: Date | null; revoked_at: Date | null }): 'active' | 'expired' | 'revoked' {
   if (row.revoked_at) return 'revoked';
   if (row.expires_at && new Date(row.expires_at).getTime() <= Date.now()) return 'expired';
   return 'active';
+}
+
+/**
+ * Resolve the expiry argument into a Date or null.
+ * Requires exactly one of { expiresIn, expiresAt } to be provided.
+ * Returns { ok: false, error } on invalid input.
+ */
+function resolveExpiresAt(
+  expiresIn: unknown,
+  expiresAt: unknown,
+): { ok: true; value: Date | null } | { ok: false; error: string } {
+  const hasIn = expiresIn !== undefined && expiresIn !== null && expiresIn !== '';
+  const hasAt = expiresAt !== undefined && expiresAt !== null && expiresAt !== '';
+
+  if (hasIn && hasAt) {
+    return { ok: false, error: 'Provide exactly one of expiresIn or expiresAt' };
+  }
+  if (!hasIn && !hasAt) {
+    return { ok: false, error: 'Provide expiresIn (including "never") or expiresAt' };
+  }
+  if (hasIn) {
+    if (expiresIn === 'never') return { ok: true, value: null };
+    if (typeof expiresIn === 'string' && EXPIRES_IN_PRESETS[expiresIn] != null) {
+      return { ok: true, value: new Date(Date.now() + EXPIRES_IN_PRESETS[expiresIn]) };
+    }
+    return { ok: false, error: 'Invalid expiresIn' };
+  }
+  if (typeof expiresAt !== 'string') {
+    return { ok: false, error: 'Invalid expiresAt' };
+  }
+  const parsed = new Date(expiresAt);
+  if (Number.isNaN(parsed.getTime())) return { ok: false, error: 'Invalid expiresAt' };
+  if (parsed.getTime() <= Date.now()) return { ok: false, error: 'expiresAt must be in the future' };
+  return { ok: true, value: parsed };
 }
 
 // POST /gt3/rides/:id/shares — create a share link for a ride
@@ -612,24 +625,8 @@ router.post('/rides/:id/shares', async (req, res) => {
   if (!userSub) return res.status(401).json({ error: 'Unauthorized' });
 
   const { expiresIn, expiresAt } = req.body ?? {};
-
-  let expiresAtDate: Date | null = null;
-  if (expiresIn === 'never' || (expiresIn == null && expiresAt == null)) {
-    expiresAtDate = null;
-  } else if (typeof expiresIn === 'string' && EXPIRES_IN_PRESETS[expiresIn] != null) {
-    expiresAtDate = new Date(Date.now() + EXPIRES_IN_PRESETS[expiresIn]);
-  } else if (typeof expiresAt === 'string') {
-    const parsed = new Date(expiresAt);
-    if (Number.isNaN(parsed.getTime())) {
-      return res.status(400).json({ error: 'Invalid expiresAt' });
-    }
-    if (parsed.getTime() <= Date.now()) {
-      return res.status(400).json({ error: 'expiresAt must be in the future' });
-    }
-    expiresAtDate = parsed;
-  } else {
-    return res.status(400).json({ error: 'Invalid expiresIn / expiresAt' });
-  }
+  const expiry = resolveExpiresAt(expiresIn, expiresAt);
+  if (!expiry.ok) return res.status(400).json({ error: expiry.error });
 
   try {
     const rideCheck = await pool.query(
@@ -640,20 +637,37 @@ router.post('/rides/:id/shares', async (req, res) => {
       return res.status(404).json({ error: 'Ride not found' });
     }
 
-    const token = generateShareToken();
-    const result = await pool.query(
-      `INSERT INTO gt3_ride_shares (token, ride_id, user_sub, expires_at)
-       VALUES ($1, $2, $3, $4)
-       RETURNING token, expires_at, created_at`,
-      [token, req.params.id, userSub, expiresAtDate],
-    );
-    const row = result.rows[0];
-    return res.json({
-      token: row.token,
-      expiresAt: row.expires_at,
-      createdAt: row.created_at,
-      status: 'active',
-    });
+    const maxAttempts = 5;
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      const token = generateShareToken();
+      const tokenHash = hashShareToken(token);
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await pool.query(
+          `INSERT INTO gt3_ride_shares (token_hash, ride_id, user_sub, expires_at)
+           VALUES ($1, $2, $3, $4)
+           RETURNING id, expires_at, created_at`,
+          [tokenHash, req.params.id, userSub, expiry.value],
+        );
+        const row = result.rows[0];
+        return res.json({
+          id: row.id,
+          token,
+          expiresAt: row.expires_at,
+          createdAt: row.created_at,
+          status: 'active',
+        });
+      } catch (err) {
+        lastErr = err;
+        const code = (err as { code?: string })?.code;
+        if (code !== '23505') throw err;
+        // token_hash collision — loop and regenerate
+      }
+    }
+
+    gt3Logger.error({ err: lastErr }, 'Failed to create ride share after repeated token collisions');
+    return res.status(500).json({ error: 'Internal server error' });
   } catch (err) {
     gt3Logger.error({ err }, 'Failed to create ride share');
     return res.status(500).json({ error: 'Internal server error' });
@@ -677,14 +691,14 @@ router.get('/rides/:id/shares', async (req, res) => {
     }
 
     const result = await pool.query(
-      `SELECT token, expires_at, revoked_at, created_at, last_accessed_at, access_count
+      `SELECT id, expires_at, revoked_at, created_at, last_accessed_at, access_count
        FROM gt3_ride_shares
        WHERE ride_id = $1 AND user_sub = $2
        ORDER BY created_at DESC`,
       [req.params.id, userSub],
     );
     const shares = result.rows.map((row: Record<string, unknown>) => ({
-      token: row.token,
+      id: row.id,
       expiresAt: row.expires_at,
       revokedAt: row.revoked_at,
       createdAt: row.created_at,
@@ -699,8 +713,8 @@ router.get('/rides/:id/shares', async (req, res) => {
   }
 });
 
-// DELETE /gt3/rides/:id/shares/:token — revoke a share link
-router.delete('/rides/:id/shares/:token', async (req, res) => {
+// DELETE /gt3/rides/:id/shares/:shareId — revoke a share link
+router.delete('/rides/:id/shares/:shareId', async (req, res) => {
   const pool = getPool();
   if (!pool) return res.status(503).json({ error: 'Database unavailable' });
   const userSub = req.user?.sub;
@@ -710,9 +724,9 @@ router.delete('/rides/:id/shares/:token', async (req, res) => {
     const result = await pool.query(
       `UPDATE gt3_ride_shares
        SET revoked_at = NOW()
-       WHERE token = $1 AND ride_id = $2 AND user_sub = $3 AND revoked_at IS NULL
-       RETURNING token`,
-      [req.params.token, req.params.id, userSub],
+       WHERE id = $1 AND ride_id = $2 AND user_sub = $3 AND revoked_at IS NULL
+       RETURNING id`,
+      [req.params.shareId, req.params.id, userSub],
     );
     if (result.rows.length === 0) {
       return res.status(404).json({ error: 'Share not found' });

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,6 +38,7 @@ import createCalendarSettingsRouter from './routes/calendar-settings.routes';
 import memoryRouter from './routes/memory.routes';
 import conversationSearchRouter from './routes/conversation-search.routes';
 import gt3Router from './routes/gt3.routes';
+import gt3PublicRouter from './routes/gt3-public.routes';
 import createMcpServer from './mcp-server';
 import { ConversationMessage, ProgressCallback, executeAICommand } from './ai-command';
 import { loadAndScheduleAll } from './scheduler';
@@ -191,6 +192,9 @@ export async function createServer(): Promise<Express> {
 
   // Serve static files (HTML/JS/CSS dashboards) — no auth required
   app.use('/gt3', express.static(path.join(__dirname, 'public', 'gt3')));
+
+  // Public GT3 share endpoints (no auth) — must be mounted before authMiddleware
+  app.use('/gt3', gt3PublicRouter);
 
   // OIDC auth routes (login, callback, logout) — unauthenticated
   app.use(createAuthRouter());


### PR DESCRIPTION
## Summary
Adds the ability for a GT3 ride owner to share individual rides via an opaque, optionally-expiring, revocable link that does **not** require the viewer to log in.

## Data model
- New `gt3_ride_shares` table keyed by an opaque `token` (32 random bytes, base64url).
- `ride_id UUID REFERENCES gt3_rides(id) ON DELETE CASCADE`, `user_sub`, optional `expires_at`, `revoked_at`, `access_count`, `last_accessed_at`.

## Owner endpoints (authenticated)
| Method | Path | Description |
|---|---|---|
| POST   | `/gt3/rides/:id/shares` | Create — `expiresIn: 1h\|24h\|7d\|30d\|never` or custom `expiresAt` ISO |
| GET    | `/gt3/rides/:id/shares` | List with computed `active \| expired \| revoked` status |
| DELETE | `/gt3/rides/:id/shares/:token` | Revoke |

## Public endpoints (no auth, mounted **before** `authMiddleware`)
- `GET /gt3/shared/:token` — ride JSON (incl. health data / heart rate).
- `GET /gt3/shared/:token/samples` — telemetry.
- `GET /gt3/shared/:token/geojson` — GPS track.

Each resolves the share, validates `revoked_at IS NULL AND (expires_at IS NULL OR expires_at > NOW())`, returns 404 otherwise, and never exposes `user_sub`. Access stats are bumped fire-and-forget.

## UI
Reuses `ride.html`:
- `?share=<token>` → public mode: skips login redirect, shows a "Shared ride" banner with expiry info.
- Owner mode adds a 🔗 Share button and modal to create links (preset / custom date-time / never) and to list / copy / revoke existing ones.
- CSRF token obtained via `/auth/csrf-token` for mutations.

## Tests
`src/__tests__/gt3-share.test.ts` — 11 tests:
- create with preset / never / custom ISO / invalid past date
- ownership enforcement (404 for non-owner)
- list returns correct `active / expired / revoked` status flags
- revoke flow (and 404 on unknown)
- public fetch success + `user_sub` is never exposed
- public fetch 404 on invalid / expired / revoked
- samples endpoint public fetch

## Validation
- `npm run lint` ✅ (no new errors; only the pre-existing warning in `live-activity-hooks.test.ts`)
- `npm run build` ✅
- `npm test` ✅ 445/445

## Out of scope (follow-ups)
- Password-protected links
- Extending an existing share's expiry (users revoke + create new)
- Rate-limiting the public endpoints