### PR TITLE
Fix OIDC token rejection and APNs broadcast errors

### DIFF
--- a/src/apns.ts
+++ b/src/apns.ts
@@ -338,6 +338,7 @@ async function sendRawBroadcast(
       'apns-topic': `${bundleId}.push-type.liveactivity`,
       'apns-push-type': 'liveactivity',
       'apns-priority': '10',
+      'apns-expiration': '0',
       'apns-channel-id': channelId,
       authorization: `bearer ${jwt}`,
       'content-type': 'application/json',

--- a/src/middleware/oidc.middleware.ts
+++ b/src/middleware/oidc.middleware.ts
@@ -76,7 +76,15 @@ export function getOidcIssuer(): Issuer<Client> | null {
 export async function validateBearerToken(
   token: string,
 ): Promise<{ sub: string; email?: string; preferred_username?: string } | null> {
-  if (!oidcIssuer) return null;
+  if (!oidcIssuer) {
+    // Attempt lazy re-initialization if OIDC failed at startup
+    oidcLogger.warn('validateBearerToken: oidcIssuer is null — attempting re-init');
+    await initOidc();
+    if (!oidcIssuer) {
+      oidcLogger.error('validateBearerToken: OIDC re-init failed, rejecting token');
+      return null;
+    }
+  }
 
   // Try local JWT validation via JWKS (fast, no network call per request)
   if (jwks) {
@@ -103,7 +111,12 @@ export async function validateBearerToken(
           preferred_username: jwtPayload.preferred_username,
         };
       } catch (err) {
-        errorState.last = err instanceof Error ? err : new Error(String(err));
+        const jwtErr = err instanceof Error ? err : new Error(String(err));
+        oidcLogger.debug(
+          { issuer, err: jwtErr.message },
+          'JWT verification failed for issuer',
+        );
+        errorState.last = jwtErr;
         return null;
       }
     };

--- a/src/middleware/oidc.middleware.ts
+++ b/src/middleware/oidc.middleware.ts
@@ -73,13 +73,34 @@ export function getOidcIssuer(): Issuer<Client> | null {
   return oidcIssuer;
 }
 
+// Rate-limit OIDC re-initialization: single-flight + cooldown
+let oidcInitPromise: Promise<void> | null = null;
+let lastOidcInitAttempt = 0;
+const OIDC_REINIT_COOLDOWN_MS = 60_000; // 1 minute
+
 export async function validateBearerToken(
   token: string,
 ): Promise<{ sub: string; email?: string; preferred_username?: string } | null> {
   if (!oidcIssuer) {
-    // Attempt lazy re-initialization if OIDC failed at startup
-    oidcLogger.warn('validateBearerToken: oidcIssuer is null — attempting re-init');
-    await initOidc();
+    const { OIDC_ISSUER_URL, OIDC_CLIENT_ID } = process.env;
+    if (!OIDC_ISSUER_URL || !OIDC_CLIENT_ID) {
+      // OIDC intentionally not configured — skip silently
+      return null;
+    }
+
+    const now = Date.now();
+    if (now - lastOidcInitAttempt < OIDC_REINIT_COOLDOWN_MS) {
+      return null;
+    }
+
+    // Single-flight: reuse in-progress init
+    if (!oidcInitPromise) {
+      lastOidcInitAttempt = now;
+      oidcLogger.warn('validateBearerToken: oidcIssuer is null — attempting re-init');
+      oidcInitPromise = initOidc().finally(() => { oidcInitPromise = null; });
+    }
+    await oidcInitPromise;
+
     if (!oidcIssuer) {
       oidcLogger.error('validateBearerToken: OIDC re-init failed, rejecting token');
       return null;


### PR DESCRIPTION
## Summary

Two server-side fixes for issues affecting iOS app authentication and Live Activity broadcasts.

### 1. Fix silent OIDC token rejection when issuer init fails

**Problem**: When OIDC discovery failed at server startup (e.g. Authentik temporarily unreachable), `validateBearerToken()` silently returned `null` for ALL bearer tokens with zero logging. This caused all iOS OIDC logins to fail with 401 — the server log showed `reason=token_rejected` but no OIDC subsystem logs explaining why.

**Fix**:
- Added lazy re-initialization: if `oidcIssuer` is null when a token arrives, attempt `initOidc()` before rejecting
- Added warn/error logging when `oidcIssuer` is null and when re-init fails
- Added debug logging for per-issuer JWT verification failures to aid troubleshooting

### 2. Fix APNs broadcast BadExpirationDate error

**Problem**: Server logs showed repeated `status=400 reason=BadExpirationDate msg=Broadcast failed` for all Live Activity broadcast pushes. The raw HTTP/2 broadcast function was missing the required `apns-expiration` header.

**Fix**:
- Added `apns-expiration: 0` header (immediate delivery, no store-and-forward) to broadcast requests
- The per-token push path already had `expiry` set correctly — only the raw broadcast was affected