### PR TITLE
Skip Live Activity for delayed start appliances

### DIFF
--- a/src/__tests__/live-activity-hooks.test.ts
+++ b/src/__tests__/live-activity-hooks.test.ts
@@ -253,4 +253,126 @@ describe('live-activity-hooks (consolidated)', () => {
       expect(mockMultiPushToStart).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('delayed start - dishwasher', () => {
+    it('treats DelayedStart as not running', async () => {
+      jest.setSystemTime(Date.now() + 500_000);
+      mockGetChannelId.mockResolvedValue('ch-consolidated');
+      mockMultiDeviceBroadcast.mockClear();
+
+      await onDishwasherStatusChange({
+        operationState: 'DelayedStart',
+        doorState: 'Closed',
+        programProgress: 0,
+        remainingTime: 3600,
+        activeProgram: 'Eco50',
+      });
+
+      const calls = mockMultiDeviceBroadcast.mock.calls;
+      if (calls.length > 0) {
+        const lastContent = calls[calls.length - 1][1];
+        const dw = lastContent.devices?.find((d: { name: string }) => d.name === 'Dishwasher');
+        expect(dw).toBeUndefined();
+      }
+    });
+
+    it('treats DelayedStart with programProgress > 0 as not running', async () => {
+      jest.setSystemTime(Date.now() + 500_000);
+      mockGetChannelId.mockResolvedValue('ch-consolidated');
+      mockMultiDeviceBroadcast.mockClear();
+
+      await onDishwasherStatusChange({
+        operationState: 'DelayedStart',
+        doorState: 'Closed',
+        programProgress: 5,
+        remainingTime: 3600,
+        activeProgram: 'Eco50',
+      });
+
+      const calls = mockMultiDeviceBroadcast.mock.calls;
+      if (calls.length > 0) {
+        const lastContent = calls[calls.length - 1][1];
+        const dw = lastContent.devices?.find((d: { name: string }) => d.name === 'Dishwasher');
+        expect(dw).toBeUndefined();
+      }
+    });
+  });
+
+  describe('delayed start - Miele', () => {
+    it('treats Programmed status as not running', async () => {
+      jest.setSystemTime(Date.now() + 600_000);
+      mockGetChannelId.mockResolvedValue('ch-consolidated');
+      mockMultiDeviceBroadcast.mockClear();
+
+      await onMieleStatusChange('washer', {
+        name: 'Washing machine',
+        timeRunning: 0,
+        timeRemaining: 120,
+        status: 'Programmed',
+        inUse: true,
+      });
+
+      const calls = mockMultiDeviceBroadcast.mock.calls;
+      if (calls.length > 0) {
+        const lastContent = calls[calls.length - 1][1];
+        const washer = lastContent.devices?.find((d: { name: string }) => d.name === 'Washer');
+        expect(washer).toBeUndefined();
+      }
+    });
+
+    it('treats Waiting to start status as not running', async () => {
+      jest.setSystemTime(Date.now() + 600_000);
+      mockGetChannelId.mockResolvedValue('ch-consolidated');
+      mockMultiDeviceBroadcast.mockClear();
+
+      await onMieleStatusChange('dryer', {
+        name: 'Tumble dryer',
+        timeRunning: 0,
+        timeRemaining: 90,
+        status: 'Waiting to start',
+        inUse: true,
+      });
+
+      const calls = mockMultiDeviceBroadcast.mock.calls;
+      if (calls.length > 0) {
+        const lastContent = calls[calls.length - 1][1];
+        const dryer = lastContent.devices?.find((d: { name: string }) => d.name === 'Dryer');
+        expect(dryer).toBeUndefined();
+      }
+    });
+
+    it('starts Live Activity when delayed start transitions to running', async () => {
+      jest.setSystemTime(Date.now() + 700_000);
+      mockGetChannelId.mockResolvedValue('ch-consolidated');
+
+      // First: programmed (not running)
+      await onMieleStatusChange('washer', {
+        name: 'Washing machine',
+        timeRunning: 0,
+        timeRemaining: 120,
+        status: 'Programmed',
+        inUse: true,
+      });
+
+      jest.setSystemTime(Date.now() + 800_000);
+      mockMultiDeviceBroadcast.mockClear();
+
+      // Then: transitions to running
+      await onMieleStatusChange('washer', {
+        name: 'Washing machine',
+        timeRunning: 5,
+        timeRemaining: 115,
+        status: 'Running',
+        inUse: true,
+      });
+
+      expect(mockMultiDeviceBroadcast).toHaveBeenCalled();
+      const lastCall = mockMultiDeviceBroadcast.mock.calls[
+        mockMultiDeviceBroadcast.mock.calls.length - 1
+      ];
+      const washer = lastCall[1].devices?.find((d: { name: string }) => d.name === 'Washer');
+      expect(washer).toBeDefined();
+      expect(washer.running).toBe(true);
+    });
+  });
 });

--- a/src/__tests__/live-activity-hooks.test.ts
+++ b/src/__tests__/live-activity-hooks.test.ts
@@ -268,7 +268,7 @@ describe('live-activity-hooks (consolidated)', () => {
         activeProgram: 'Eco50',
       });
 
-      const calls = mockMultiDeviceBroadcast.mock.calls;
+      const { calls } = mockMultiDeviceBroadcast.mock;
       if (calls.length > 0) {
         const lastContent = calls[calls.length - 1][1];
         const dw = lastContent.devices?.find((d: { name: string }) => d.name === 'Dishwasher');
@@ -289,7 +289,7 @@ describe('live-activity-hooks (consolidated)', () => {
         activeProgram: 'Eco50',
       });
 
-      const calls = mockMultiDeviceBroadcast.mock.calls;
+      const { calls } = mockMultiDeviceBroadcast.mock;
       if (calls.length > 0) {
         const lastContent = calls[calls.length - 1][1];
         const dw = lastContent.devices?.find((d: { name: string }) => d.name === 'Dishwasher');
@@ -312,7 +312,7 @@ describe('live-activity-hooks (consolidated)', () => {
         inUse: true,
       });
 
-      const calls = mockMultiDeviceBroadcast.mock.calls;
+      const { calls } = mockMultiDeviceBroadcast.mock;
       if (calls.length > 0) {
         const lastContent = calls[calls.length - 1][1];
         const washer = lastContent.devices?.find((d: { name: string }) => d.name === 'Washer');
@@ -333,7 +333,7 @@ describe('live-activity-hooks (consolidated)', () => {
         inUse: true,
       });
 
-      const calls = mockMultiDeviceBroadcast.mock.calls;
+      const { calls } = mockMultiDeviceBroadcast.mock;
       if (calls.length > 0) {
         const lastContent = calls[calls.length - 1][1];
         const dryer = lastContent.devices?.find((d: { name: string }) => d.name === 'Dryer');

--- a/src/live-activity-hooks.ts
+++ b/src/live-activity-hooks.ts
@@ -76,7 +76,10 @@ function buildMieleContentState(
     trailingText = `${device.status} · ${trailingText}`;
   }
 
-  const running = (device.timeRemaining ?? 0) > 0;
+  // Treat delayed/programmed states as not running — the Live Activity
+  // should only appear once the appliance actually starts its cycle.
+  const isDelayed = device.status === 'Programmed' || device.status === 'Waiting to start';
+  const running = !isDelayed && (device.timeRemaining ?? 0) > 0;
 
   return {
     device: {
@@ -131,7 +134,10 @@ function buildDishwasherContentState(dishwasher: DishWasher): LiveActivityConten
     trailingText = `${dishwasher.operationState} · ${trailingText}`;
   }
 
-  const running = (dishwasher.programProgress ?? 0) > 0;
+  // Treat delayed start as not running — the Live Activity
+  // should only appear once the appliance actually starts its cycle.
+  const running = dishwasher.operationState !== 'DelayedStart'
+    && (dishwasher.programProgress ?? 0) > 0;
 
   return {
     device: {
@@ -306,7 +312,7 @@ export async function onMieleStatusChange(
   const name = deviceType === 'washer' ? 'Washer' : 'Dryer';
   const icon = deviceType === 'washer' ? 'washer' : 'dryer';
   const contentState = buildMieleContentState(name, icon, device);
-  const running = (device.timeRemaining ?? 0) > 0;
+  const { running } = contentState.device;
 
   // Cache for consolidated activity
   cachedDeviceStates.set(activityType, contentState.device);
@@ -336,7 +342,7 @@ export async function onMieleStatusChange(
 export async function onDishwasherStatusChange(dishwasher: DishWasher): Promise<void> {
   const activityType = 'dishwasher';
   const contentState = buildDishwasherContentState(dishwasher);
-  const running = (dishwasher.programProgress ?? 0) > 0;
+  const { running } = contentState.device;
 
   // Cache for consolidated activity
   cachedDeviceStates.set(activityType, contentState.device);


### PR DESCRIPTION
## Summary

When an appliance (washer, dryer, dishwasher) is set with a delayed start, the Live Activity was incorrectly popping up immediately — even though the actual cycle won't begin for hours.

### Root cause

The `running` flag was determined solely by `timeRemaining > 0` (Miele) or `programProgress > 0` (HomeConnect), without checking whether the appliance is actually running vs waiting for a delayed start.

### Fix

- **Miele washer/dryer**: Exclude `Programmed` and `Waiting to start` status from being treated as running
- **HomeConnect dishwasher**: Exclude `DelayedStart` operationState from being treated as running
- **Unified running logic**: Callers now use `contentState.device.running` (via destructuring) instead of duplicating the running determination

Once the delay expires and the appliance transitions to `Running` / `Run`, the next poll cycle will detect it as running and start the Live Activity normally.