### PR TITLE
feat(gt3): add Catppuccin light/dark theme support

### DIFF
--- a/src/public/gt3/dashboard.js
+++ b/src/public/gt3/dashboard.js
@@ -5,26 +5,33 @@ const API_BASE = '/gt3';
 let currentPage = 1;
 const PAGE_SIZE = 20;
 
-// Catppuccin Mocha chart palette
-const CHART_COLORS = {
-  sky: '#89dceb',
-  sapphire: '#74c7ec',
-  mauve: '#cba6f7',
-  green: '#a6e3a1',
-  peach: '#fab387',
-  red: '#f38ba8',
-  blue: '#89b4fa',
-  teal: '#94e2d5',
-  pink: '#f5c2e7',
-  yellow: '#f9e2af',
-  text: '#cdd6f4',
-  subtext: '#a6adc8',
-  surface: '#313244',
-  overlay: '#6c7086',
-};
+// Read Catppuccin palette from CSS custom properties (respects light/dark)
+function getChartColors() {
+  const s = getComputedStyle(document.documentElement);
+  const v = (name) => s.getPropertyValue(name).trim();
+  return {
+    sky: v('--sky'), sapphire: v('--sapphire'), mauve: v('--mauve'),
+    green: v('--green'), peach: v('--peach'), red: v('--red'),
+    blue: v('--blue'), teal: v('--teal'), pink: v('--pink'),
+    yellow: v('--yellow'), text: v('--text'), subtext: v('--subtext0'),
+    surface: v('--surface0'), overlay: v('--overlay0'),
+  };
+}
+let CHART_COLORS = getChartColors();
 
-Chart.defaults.color = CHART_COLORS.subtext;
-Chart.defaults.borderColor = CHART_COLORS.surface;
+function applyChartDefaults() {
+  CHART_COLORS = getChartColors();
+  Chart.defaults.color = CHART_COLORS.subtext;
+  Chart.defaults.borderColor = CHART_COLORS.surface;
+}
+applyChartDefaults();
+
+// Re-render on theme change
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+  applyChartDefaults();
+  loadStats();
+  loadRides(currentPage);
+});
 
 // ── Helpers ────────────────────────────────────────────────
 

--- a/src/public/gt3/ride-detail.js
+++ b/src/public/gt3/ride-detail.js
@@ -2,24 +2,35 @@
 
 const API_BASE = '/gt3';
 
-const CHART_COLORS = {
-  sky: '#89dceb',
-  sapphire: '#74c7ec',
-  mauve: '#cba6f7',
-  green: '#a6e3a1',
-  peach: '#fab387',
-  red: '#f38ba8',
-  blue: '#89b4fa',
-  teal: '#94e2d5',
-  pink: '#f5c2e7',
-  yellow: '#f9e2af',
-  text: '#cdd6f4',
-  subtext: '#a6adc8',
-  surface: '#313244',
-};
+// Read Catppuccin palette from CSS custom properties (respects light/dark)
+function getChartColors() {
+  const s = getComputedStyle(document.documentElement);
+  const v = (name) => s.getPropertyValue(name).trim();
+  return {
+    sky: v('--sky'), sapphire: v('--sapphire'), mauve: v('--mauve'),
+    green: v('--green'), peach: v('--peach'), red: v('--red'),
+    blue: v('--blue'), teal: v('--teal'), pink: v('--pink'),
+    yellow: v('--yellow'), text: v('--text'), subtext: v('--subtext0'),
+    surface: v('--surface0'),
+  };
+}
+let CHART_COLORS = getChartColors();
 
-Chart.defaults.color = CHART_COLORS.subtext;
-Chart.defaults.borderColor = CHART_COLORS.surface;
+function applyChartDefaults() {
+  CHART_COLORS = getChartColors();
+  Chart.defaults.color = CHART_COLORS.subtext;
+  Chart.defaults.borderColor = CHART_COLORS.surface;
+}
+applyChartDefaults();
+
+function isLightMode() {
+  return window.matchMedia('(prefers-color-scheme: light)').matches;
+}
+
+function cartoTileUrl() {
+  const variant = isLightMode() ? 'light_all' : 'rastertiles/voyager';
+  return `https://{s}.basemaps.cartocdn.com/${variant}/{z}/{x}/{y}{r}.png`;
+}
 
 const GEAR_NAMES = { 1: 'Eco', 2: 'Standard', 3: 'Sport', 4: 'Race' };
 const GEAR_COLORS = { 1: '#a6e3a1', 2: '#89b4fa', 3: '#fab387', 4: '#f38ba8' };
@@ -277,7 +288,7 @@ async function loadRide() {
   // ── Map ─────────────────────────────────────────────────
   if (ride.gps_track && Array.isArray(ride.gps_track) && ride.gps_track.length > 0) {
     const map = L.map('map', { attributionControl: true });
-    L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+    L.tileLayer(cartoTileUrl(), {
       attribution: '&copy; OpenStreetMap contributors, &copy; CARTO',
       maxZoom: 19,
     }).addTo(map);
@@ -673,3 +684,9 @@ async function refreshShareList(rideId) {
 }
 
 loadRide();
+
+// Re-render on theme change
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+  applyChartDefaults();
+  loadRide();
+});

--- a/src/public/gt3/style.css
+++ b/src/public/gt3/style.css
@@ -1,6 +1,6 @@
-/* GT3 Pro Dashboard — Catppuccin Mocha Theme */
+/* GT3 Pro Dashboard — Catppuccin Mocha / Latte Theme */
 
-/* ── CSS Custom Properties ─────────────────────────────────── */
+/* ── CSS Custom Properties (Mocha — dark, default) ─────────── */
 :root {
   --base: #1e1e2e;
   --mantle: #181825;
@@ -28,6 +28,35 @@
   --radius: 12px;
   --radius-sm: 6px;
   --transition: 150ms ease;
+}
+
+/* ── Catppuccin Latte (light) ──────────────────────────────── */
+@media (prefers-color-scheme: light) {
+  :root {
+    --base: #eff1f5;
+    --mantle: #e6e9ef;
+    --crust: #dce0e8;
+    --surface0: #ccd0da;
+    --surface1: #bcc0cc;
+    --surface2: #acb0be;
+    --text: #4c4f69;
+    --subtext1: #5c5f77;
+    --subtext0: #6c6f85;
+    --overlay0: #9ca0b0;
+    --overlay1: #8c8fa1;
+    --sky: #04a5e5;
+    --sapphire: #209fb5;
+    --green: #40a02b;
+    --red: #d20f39;
+    --yellow: #df8e1d;
+    --peach: #fe640b;
+    --mauve: #8839ef;
+    --blue: #1e66f5;
+    --teal: #179299;
+    --pink: #ea76cb;
+    --flamingo: #dd7878;
+    --rosewater: #dc8a78;
+  }
 }
 
 /* ── Reset / Normalize ─────────────────────────────────────── */


### PR DESCRIPTION
- Add Catppuccin Latte (light) theme via prefers-color-scheme media query
- Read chart colors from CSS custom properties so they follow the active theme
- Re-render charts and map on system theme change
- Switch map tiles to CARTO Voyager for dark mode (better readability)
- Use CARTO Light for light mode