### PR TITLE
Add secure GT3 ride photo API

### DIFF
--- a/src/__tests__/gt3-photos.test.ts
+++ b/src/__tests__/gt3-photos.test.ts
@@ -55,19 +55,28 @@ function validPayload(overrides: Record<string, unknown> = {}) {
 
 describe('GT3 ride photos', () => {
   let mockQuery: jest.Mock;
+  let mockClientQuery: jest.Mock;
+  let mockRelease: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockQuery = jest.fn();
-    (getPool as jest.Mock).mockReturnValue({ query: mockQuery, connect: jest.fn() });
+    mockClientQuery = jest.fn();
+    mockRelease = jest.fn();
+    (getPool as jest.Mock).mockReturnValue({
+      query: mockQuery,
+      connect: jest.fn().mockResolvedValue({ query: mockClientQuery, release: mockRelease }),
+    });
   });
 
   describe('POST /gt3/rides/:id/photos', () => {
     it('stores a validated JPEG photo for an owned ride', async () => {
-      mockQuery
+      mockClientQuery
+        .mockResolvedValueOnce({ rows: [] })
         .mockResolvedValueOnce({ rows: [{ id: RIDE_ID }] })
         .mockResolvedValueOnce({ rows: [{ count: 0 }] })
-        .mockResolvedValueOnce({ rows: [{ id: PHOTO_ID }] });
+        .mockResolvedValueOnce({ rows: [{ id: PHOTO_ID }] })
+        .mockResolvedValueOnce({ rows: [] });
 
       const res = await request(buildApp(USER_SUB))
         .post(`/gt3/rides/${RIDE_ID}/photos`)
@@ -75,13 +84,17 @@ describe('GT3 ride photos', () => {
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ ok: true, id: PHOTO_ID });
-      expect(mockQuery.mock.calls[0][1]).toEqual([RIDE_ID, USER_SUB]);
-      const insertArgs = mockQuery.mock.calls[2][1];
+      expect(mockClientQuery.mock.calls[0][0]).toBe('BEGIN');
+      expect(mockClientQuery.mock.calls[1][0]).toContain('FOR UPDATE');
+      expect(mockClientQuery.mock.calls[1][1]).toEqual([RIDE_ID, USER_SUB]);
+      const insertArgs = mockClientQuery.mock.calls[3][1];
       expect(insertArgs[0]).toBe(RIDE_ID);
       expect(insertArgs[1]).toBe(USER_SUB);
       expect(insertArgs[5]).toBe('image/jpeg');
       expect(Buffer.isBuffer(insertArgs[6])).toBe(true);
       expect(insertArgs[6]).toEqual(jpegBytes);
+      expect(mockClientQuery.mock.calls[4][0]).toBe('COMMIT');
+      expect(mockRelease).toHaveBeenCalledTimes(1);
     });
 
     it('requires an authenticated OIDC user', async () => {
@@ -94,13 +107,18 @@ describe('GT3 ride photos', () => {
     });
 
     it('returns 404 when the ride is not owned by the user', async () => {
-      mockQuery.mockResolvedValueOnce({ rows: [] });
+      mockClientQuery
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] });
 
       const res = await request(buildApp(USER_SUB))
         .post(`/gt3/rides/${RIDE_ID}/photos`)
         .send(validPayload());
 
       expect(res.status).toBe(404);
+      expect(mockClientQuery.mock.calls[2][0]).toBe('ROLLBACK');
+      expect(mockRelease).toHaveBeenCalledTimes(1);
     });
 
     it('rejects unsupported mime types', async () => {
@@ -131,6 +149,16 @@ describe('GT3 ride photos', () => {
         .send(validPayload({ capturedAt: 'not-a-date' }));
       expect(badDate.status).toBe(400);
 
+      const nonISODate = await request(buildApp(USER_SUB))
+        .post(`/gt3/rides/${RIDE_ID}/photos`)
+        .send(validPayload({ capturedAt: 'May 10 2026 09:00:00' }));
+      expect(nonISODate.status).toBe(400);
+
+      const invalidISODate = await request(buildApp(USER_SUB))
+        .post(`/gt3/rides/${RIDE_ID}/photos`)
+        .send(validPayload({ capturedAt: '2026-02-31T09:00:00Z' }));
+      expect(invalidISODate.status).toBe(400);
+
       const badLatitude = await request(buildApp(USER_SUB))
         .post(`/gt3/rides/${RIDE_ID}/photos`)
         .send(validPayload({ latitude: 91 }));
@@ -144,33 +172,37 @@ describe('GT3 ride photos', () => {
     });
 
     it('enforces the per-ride photo cap', async () => {
-      mockQuery
+      mockClientQuery
+        .mockResolvedValueOnce({ rows: [] })
         .mockResolvedValueOnce({ rows: [{ id: RIDE_ID }] })
-        .mockResolvedValueOnce({ rows: [{ count: 200 }] });
+        .mockResolvedValueOnce({ rows: [{ count: 200 }] })
+        .mockResolvedValueOnce({ rows: [] });
 
       const res = await request(buildApp(USER_SUB))
         .post(`/gt3/rides/${RIDE_ID}/photos`)
         .send(validPayload());
 
       expect(res.status).toBe(409);
-      expect(mockQuery).toHaveBeenCalledTimes(2);
+      expect(mockClientQuery).toHaveBeenCalledTimes(4);
+      expect(mockClientQuery.mock.calls[3][0]).toBe('ROLLBACK');
     });
   });
 
   describe('GET /gt3/rides/:id/photos', () => {
     it('returns metadata without image bytes', async () => {
-      mockQuery.mockResolvedValueOnce({
-        rows: [{
-          ride_id: RIDE_ID,
-          id: PHOTO_ID,
-          captured_at: new Date(),
-          latitude: 43,
-          longitude: -79,
-          mime_type: 'image/jpeg',
-          byte_length: jpegBytes.length,
-          created_at: new Date(),
-        }],
-      });
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: RIDE_ID }] })
+        .mockResolvedValueOnce({
+          rows: [{
+            id: PHOTO_ID,
+            captured_at: new Date(),
+            latitude: 43,
+            longitude: -79,
+            mime_type: 'image/jpeg',
+            byte_length: jpegBytes.length,
+            created_at: new Date(),
+          }],
+        });
 
       const res = await request(buildApp(USER_SUB)).get(`/gt3/rides/${RIDE_ID}/photos`);
 
@@ -179,6 +211,27 @@ describe('GT3 ride photos', () => {
       expect(res.body.photos[0].id).toBe(PHOTO_ID);
       expect(res.body.photos[0].imageData).toBeUndefined();
       expect(mockQuery.mock.calls[0][1]).toEqual([RIDE_ID, USER_SUB]);
+      expect(mockQuery.mock.calls[1][0]).toContain('FROM gt3_ride_photos');
+    });
+
+    it('returns an empty list for owned rides without photos', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: RIDE_ID }] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(buildApp(USER_SUB)).get(`/gt3/rides/${RIDE_ID}/photos`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.photos).toEqual([]);
+    });
+
+    it('returns 404 before querying photos when the ride is not owned', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(buildApp(USER_SUB)).get(`/gt3/rides/${RIDE_ID}/photos`);
+
+      expect(res.status).toBe(404);
+      expect(mockQuery).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -200,6 +253,7 @@ describe('GT3 ride photos', () => {
       expect(res.status).toBe(200);
       expect(res.headers['content-type']).toContain('image/jpeg');
       expect(res.headers['x-content-type-options']).toBe('nosniff');
+      expect(res.headers.etag).toMatch(new RegExp(`^"gt3-photo-${PHOTO_ID}-[a-f0-9]{64}"$`));
       expect(res.body).toEqual(jpegBytes);
       expect(mockQuery.mock.calls[0][1]).toEqual([PHOTO_ID, RIDE_ID, USER_SUB]);
     });

--- a/src/__tests__/gt3-photos.test.ts
+++ b/src/__tests__/gt3-photos.test.ts
@@ -1,0 +1,285 @@
+import request from 'supertest';
+import express from 'express';
+import gt3Router from '../routes/gt3.routes';
+import gt3PublicRouter from '../routes/gt3-public.routes';
+
+jest.mock('../logger', () => ({
+  __esModule: true,
+  default: {
+    child: () => ({
+      info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+    }),
+  },
+}));
+
+jest.mock('../db', () => ({
+  getPool: jest.fn(),
+}));
+
+jest.mock('../influx', () => ({ writePoint: jest.fn() }));
+jest.mock('../clients/influxdb', () => ({
+  InfluxDBClient: jest.fn().mockImplementation(() => ({ configured: false, query: jest.fn() })),
+}));
+jest.mock('../apns', () => ({ sendGT3PushToStart: jest.fn() }));
+jest.mock('../push-token-store', () => ({ getDeviceTokensByUserAndBundle: jest.fn() }));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+const { getPool } = require('../db');
+
+const USER_SUB = 'owner-sub';
+const RIDE_ID = '11111111-1111-1111-1111-111111111111';
+const PHOTO_ID = '22222222-2222-2222-2222-222222222222';
+const jpegBytes = Buffer.from([0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43]);
+
+function buildApp(userSub: string | null) {
+  const app = express();
+  app.use(express.json({ limit: '12mb' }));
+  app.use('/gt3', gt3PublicRouter);
+  app.use('/gt3', (req, _res, next) => {
+    if (userSub) req.user = { sub: userSub, role: 'admin', username: 'u' };
+    next();
+  }, gt3Router);
+  return app;
+}
+
+function validPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    capturedAt: new Date().toISOString(),
+    latitude: 43.6532,
+    longitude: -79.3832,
+    mimeType: 'image/jpeg',
+    imageData: jpegBytes.toString('base64'),
+    ...overrides,
+  };
+}
+
+describe('GT3 ride photos', () => {
+  let mockQuery: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQuery = jest.fn();
+    (getPool as jest.Mock).mockReturnValue({ query: mockQuery, connect: jest.fn() });
+  });
+
+  describe('POST /gt3/rides/:id/photos', () => {
+    it('stores a validated JPEG photo for an owned ride', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: RIDE_ID }] })
+        .mockResolvedValueOnce({ rows: [{ count: 0 }] })
+        .mockResolvedValueOnce({ rows: [{ id: PHOTO_ID }] });
+
+      const res = await request(buildApp(USER_SUB))
+        .post(`/gt3/rides/${RIDE_ID}/photos`)
+        .send(validPayload());
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true, id: PHOTO_ID });
+      expect(mockQuery.mock.calls[0][1]).toEqual([RIDE_ID, USER_SUB]);
+      const insertArgs = mockQuery.mock.calls[2][1];
+      expect(insertArgs[0]).toBe(RIDE_ID);
+      expect(insertArgs[1]).toBe(USER_SUB);
+      expect(insertArgs[5]).toBe('image/jpeg');
+      expect(Buffer.isBuffer(insertArgs[6])).toBe(true);
+      expect(insertArgs[6]).toEqual(jpegBytes);
+    });
+
+    it('requires an authenticated OIDC user', async () => {
+      const res = await request(buildApp(null))
+        .post(`/gt3/rides/${RIDE_ID}/photos`)
+        .send(validPayload());
+
+      expect(res.status).toBe(401);
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when the ride is not owned by the user', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(buildApp(USER_SUB))
+        .post(`/gt3/rides/${RIDE_ID}/photos`)
+        .send(validPayload());
+
+      expect(res.status).toBe(404);
+    });
+
+    it('rejects unsupported mime types', async () => {
+      const res = await request(buildApp(USER_SUB))
+        .post(`/gt3/rides/${RIDE_ID}/photos`)
+        .send(validPayload({ mimeType: 'image/png' }));
+
+      expect(res.status).toBe(400);
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid base64 and non-JPEG bytes', async () => {
+      const invalidBase64 = await request(buildApp(USER_SUB))
+        .post(`/gt3/rides/${RIDE_ID}/photos`)
+        .send(validPayload({ imageData: 'not base64' }));
+      expect(invalidBase64.status).toBe(400);
+
+      const nonJPEG = await request(buildApp(USER_SUB))
+        .post(`/gt3/rides/${RIDE_ID}/photos`)
+        .send(validPayload({ imageData: Buffer.from('hello').toString('base64') }));
+      expect(nonJPEG.status).toBe(400);
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid dates and coordinates', async () => {
+      const badDate = await request(buildApp(USER_SUB))
+        .post(`/gt3/rides/${RIDE_ID}/photos`)
+        .send(validPayload({ capturedAt: 'not-a-date' }));
+      expect(badDate.status).toBe(400);
+
+      const badLatitude = await request(buildApp(USER_SUB))
+        .post(`/gt3/rides/${RIDE_ID}/photos`)
+        .send(validPayload({ latitude: 91 }));
+      expect(badLatitude.status).toBe(400);
+
+      const missingLongitude = await request(buildApp(USER_SUB))
+        .post(`/gt3/rides/${RIDE_ID}/photos`)
+        .send(validPayload({ longitude: null }));
+      expect(missingLongitude.status).toBe(400);
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it('enforces the per-ride photo cap', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: RIDE_ID }] })
+        .mockResolvedValueOnce({ rows: [{ count: 200 }] });
+
+      const res = await request(buildApp(USER_SUB))
+        .post(`/gt3/rides/${RIDE_ID}/photos`)
+        .send(validPayload());
+
+      expect(res.status).toBe(409);
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('GET /gt3/rides/:id/photos', () => {
+    it('returns metadata without image bytes', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{
+          ride_id: RIDE_ID,
+          id: PHOTO_ID,
+          captured_at: new Date(),
+          latitude: 43,
+          longitude: -79,
+          mime_type: 'image/jpeg',
+          byte_length: jpegBytes.length,
+          created_at: new Date(),
+        }],
+      });
+
+      const res = await request(buildApp(USER_SUB)).get(`/gt3/rides/${RIDE_ID}/photos`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.photos).toHaveLength(1);
+      expect(res.body.photos[0].id).toBe(PHOTO_ID);
+      expect(res.body.photos[0].imageData).toBeUndefined();
+      expect(mockQuery.mock.calls[0][1]).toEqual([RIDE_ID, USER_SUB]);
+    });
+  });
+
+  describe('GET /gt3/rides/:id/photos/:photoId', () => {
+    it('returns owned photo bytes with safe headers', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{
+          id: PHOTO_ID,
+          captured_at: new Date(),
+          mime_type: 'image/jpeg',
+          image_data: jpegBytes,
+          created_at: new Date(),
+        }],
+      });
+
+      const res = await request(buildApp(USER_SUB))
+        .get(`/gt3/rides/${RIDE_ID}/photos/${PHOTO_ID}`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('image/jpeg');
+      expect(res.headers['x-content-type-options']).toBe('nosniff');
+      expect(res.body).toEqual(jpegBytes);
+      expect(mockQuery.mock.calls[0][1]).toEqual([PHOTO_ID, RIDE_ID, USER_SUB]);
+    });
+  });
+
+  describe('public shared ride photos', () => {
+    it('includes photo metadata in shared ride responses without raw bytes', async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{
+            id: 'share-id', ride_id: RIDE_ID, expires_at: null, revoked_at: null,
+          }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{
+            id: RIDE_ID,
+            start_time: new Date(),
+            end_time: null,
+            distance: 10,
+            max_speed: 40,
+            avg_speed: 20,
+            battery_used: 5,
+            start_battery: 100,
+            end_battery: 95,
+            gear_mode: 2,
+            gps_track: null,
+            health_data: null,
+            metadata: null,
+            created_at: new Date(),
+          }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{
+            id: PHOTO_ID,
+            captured_at: new Date(),
+            latitude: 43,
+            longitude: -79,
+            mime_type: 'image/jpeg',
+            byte_length: jpegBytes.length,
+            created_at: new Date(),
+          }],
+        })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(buildApp(null)).get('/gt3/shared/raw-token');
+
+      expect(res.status).toBe(200);
+      expect(res.body.photos).toHaveLength(1);
+      expect(res.body.photos[0].imageData).toBeUndefined();
+      expect(res.body.share.token).toBeUndefined();
+    });
+
+    it('serves shared photo bytes only when the photo belongs to the shared ride', async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{
+            share_id: 'share-id',
+            id: PHOTO_ID,
+            captured_at: new Date(),
+            mime_type: 'image/jpeg',
+            image_data: jpegBytes,
+            created_at: new Date(),
+          }],
+        })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(buildApp(null)).get(`/gt3/shared/token/photos/${PHOTO_ID}`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('image/jpeg');
+      expect(mockQuery.mock.calls[0][0]).toContain('JOIN gt3_ride_photos p ON p.ride_id = s.ride_id');
+      expect(mockQuery.mock.calls[0][1][1]).toBe(PHOTO_ID);
+    });
+
+    it('returns 404 for expired, revoked, unknown, or mismatched shared photos', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(buildApp(null)).get(`/gt3/shared/token/photos/${PHOTO_ID}`);
+
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/src/__tests__/gt3-share.test.ts
+++ b/src/__tests__/gt3-share.test.ts
@@ -261,6 +261,7 @@ describe('GT3 ride share links', () => {
             created_at: new Date(),
           }],
         })
+        .mockResolvedValueOnce({ rows: [] }) // photos
         .mockResolvedValueOnce({ rows: [] }); // bumpAccess (fire-and-forget)
 
       // No auth — anonymous request

--- a/src/db.ts
+++ b/src/db.ts
@@ -298,6 +298,22 @@ export async function initDatabase(): Promise<void> {
       );
       CREATE INDEX IF NOT EXISTS idx_gt3_samples_ride ON gt3_samples (ride_id, timestamp);
 
+      CREATE TABLE IF NOT EXISTS gt3_ride_photos (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        ride_id UUID NOT NULL REFERENCES gt3_rides(id) ON DELETE CASCADE,
+        user_sub TEXT NOT NULL,
+        captured_at TIMESTAMPTZ NOT NULL,
+        latitude DOUBLE PRECISION,
+        longitude DOUBLE PRECISION,
+        mime_type TEXT NOT NULL,
+        image_data BYTEA NOT NULL,
+        created_at TIMESTAMPTZ DEFAULT NOW()
+      );
+      CREATE INDEX IF NOT EXISTS idx_gt3_ride_photos_ride
+        ON gt3_ride_photos (ride_id, captured_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_gt3_ride_photos_user
+        ON gt3_ride_photos (user_sub, created_at DESC);
+
       CREATE TABLE IF NOT EXISTS gt3_ride_shares (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
         token_hash TEXT NOT NULL UNIQUE,

--- a/src/gt3-photos.ts
+++ b/src/gt3-photos.ts
@@ -1,0 +1,145 @@
+import { Response } from 'express';
+
+export const GT3_PHOTO_MIME_TYPE = 'image/jpeg';
+export const MAX_GT3_PHOTO_BYTES = 7_500_000;
+export const MAX_GT3_PHOTOS_PER_RIDE = 200;
+
+export type RidePhotoPayload = {
+  capturedAt?: unknown;
+  latitude?: unknown;
+  longitude?: unknown;
+  mimeType?: unknown;
+  imageData?: unknown;
+};
+
+export type ValidRidePhotoPayload = {
+  capturedAt: Date;
+  latitude: number | null;
+  longitude: number | null;
+  mimeType: typeof GT3_PHOTO_MIME_TYPE;
+  imageData: Buffer;
+};
+
+export type RidePhotoMetadataRow = {
+  id: string;
+  captured_at: Date;
+  latitude: number | null;
+  longitude: number | null;
+  mime_type: string;
+  byte_length: string | number;
+  created_at: Date;
+};
+
+export type RidePhotoBytesRow = {
+  id: string;
+  captured_at: Date;
+  mime_type: string;
+  image_data: Buffer;
+  created_at: Date;
+};
+
+export function ridePhotoMetadata(row: RidePhotoMetadataRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    capturedAt: row.captured_at,
+    latitude: row.latitude,
+    longitude: row.longitude,
+    mimeType: row.mime_type,
+    byteLength: Number(row.byte_length),
+    createdAt: row.created_at,
+  };
+}
+
+function parseOptionalCoordinate(
+  value: unknown,
+  min: number,
+  max: number,
+): { ok: true; value: number | null } | { ok: false; error: string } {
+  if (value === undefined || value === null) return { ok: true, value: null };
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < min || value > max) {
+    return { ok: false, error: `coordinate must be a finite number between ${min} and ${max}` };
+  }
+  return { ok: true, value };
+}
+
+function decodeBase64Image(value: unknown): Buffer | null {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  if (value.length > Math.ceil(MAX_GT3_PHOTO_BYTES / 3) * 4) return null;
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value) || value.length % 4 !== 0) return null;
+  const decoded = Buffer.from(value, 'base64');
+  if (decoded.length === 0 || decoded.length > MAX_GT3_PHOTO_BYTES) return null;
+  if (decoded.toString('base64') !== value) return null;
+  return decoded;
+}
+
+function isJPEG(data: Buffer): boolean {
+  return data.length >= 3
+    && data[0] === 0xff
+    && data[1] === 0xd8
+    && data[2] === 0xff;
+}
+
+export function validateRidePhotoPayload(
+  payload: RidePhotoPayload,
+): { ok: true; value: ValidRidePhotoPayload } | { ok: false; status: number; error: string } {
+  if (payload.mimeType !== GT3_PHOTO_MIME_TYPE) {
+    return { ok: false, status: 400, error: 'mimeType must be image/jpeg' };
+  }
+
+  if (typeof payload.capturedAt !== 'string') {
+    return { ok: false, status: 400, error: 'capturedAt must be an ISO8601 string' };
+  }
+  const capturedAt = new Date(payload.capturedAt);
+  if (Number.isNaN(capturedAt.getTime())) {
+    return { ok: false, status: 400, error: 'capturedAt must be a valid date' };
+  }
+  const earliest = new Date('2020-01-01T00:00:00Z');
+  const latest = Date.now() + 24 * 60 * 60 * 1000;
+  if (capturedAt < earliest || capturedAt.getTime() > latest) {
+    return { ok: false, status: 400, error: 'capturedAt is outside the accepted range' };
+  }
+
+  const lat = parseOptionalCoordinate(payload.latitude, -90, 90);
+  if (!lat.ok) return { ok: false, status: 400, error: `latitude ${lat.error}` };
+  const lon = parseOptionalCoordinate(payload.longitude, -180, 180);
+  if (!lon.ok) return { ok: false, status: 400, error: `longitude ${lon.error}` };
+  if ((lat.value === null) !== (lon.value === null)) {
+    return { ok: false, status: 400, error: 'latitude and longitude must be provided together' };
+  }
+
+  const imageData = decodeBase64Image(payload.imageData);
+  if (!imageData) {
+    return { ok: false, status: 400, error: 'imageData must be valid base64 JPEG data' };
+  }
+  if (!isJPEG(imageData)) {
+    return { ok: false, status: 400, error: 'imageData must contain JPEG bytes' };
+  }
+
+  return {
+    ok: true,
+    value: {
+      capturedAt,
+      latitude: lat.value,
+      longitude: lon.value,
+      mimeType: GT3_PHOTO_MIME_TYPE,
+      imageData,
+    },
+  };
+}
+
+export function sendRidePhotoBytes(res: Response, row: RidePhotoBytesRow): Response {
+  const data = row.image_data;
+  const etag = `"gt3-photo-${row.id}-${data.length}"`;
+  if (res.req.headers['if-none-match'] === etag) {
+    return res.status(304).end();
+  }
+  res.setHeader('Content-Type', row.mime_type);
+  res.setHeader('Content-Length', String(data.length));
+  res.setHeader('Content-Disposition', `inline; filename="${row.id}.jpg"`);
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('Content-Security-Policy', "default-src 'none'; sandbox");
+  res.setHeader('Cache-Control', 'private, max-age=86400');
+  res.setHeader('ETag', etag);
+  res.setHeader('Last-Modified', new Date(row.created_at).toUTCString());
+  return res.send(data);
+}

--- a/src/gt3-photos.ts
+++ b/src/gt3-photos.ts
@@ -1,4 +1,5 @@
 import { Response } from 'express';
+import { createHash } from 'crypto';
 
 export const GT3_PHOTO_MIME_TYPE = 'image/jpeg';
 export const MAX_GT3_PHOTO_BYTES = 7_500_000;
@@ -79,6 +80,21 @@ function isJPEG(data: Buffer): boolean {
     && data[2] === 0xff;
 }
 
+function isISO8601DateTime(value: string): boolean {
+  const match = value.match(
+    /^(\d{4})-(\d{2})-(\d{2})T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d{1,9})?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/,
+  );
+  if (!match) return false;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year
+    && date.getUTCMonth() === month - 1
+    && date.getUTCDate() === day;
+}
+
 export function validateRidePhotoPayload(
   payload: RidePhotoPayload,
 ): { ok: true; value: ValidRidePhotoPayload } | { ok: false; status: number; error: string } {
@@ -87,6 +103,9 @@ export function validateRidePhotoPayload(
   }
 
   if (typeof payload.capturedAt !== 'string') {
+    return { ok: false, status: 400, error: 'capturedAt must be an ISO8601 string' };
+  }
+  if (!isISO8601DateTime(payload.capturedAt)) {
     return { ok: false, status: 400, error: 'capturedAt must be an ISO8601 string' };
   }
   const capturedAt = new Date(payload.capturedAt);
@@ -129,7 +148,8 @@ export function validateRidePhotoPayload(
 
 export function sendRidePhotoBytes(res: Response, row: RidePhotoBytesRow): Response {
   const data = row.image_data;
-  const etag = `"gt3-photo-${row.id}-${data.length}"`;
+  const contentHash = createHash('sha256').update(data).digest('hex');
+  const etag = `"gt3-photo-${row.id}-${contentHash}"`;
   if (res.req.headers['if-none-match'] === etag) {
     return res.status(304).end();
   }

--- a/src/routes/gt3-public.routes.ts
+++ b/src/routes/gt3-public.routes.ts
@@ -3,6 +3,12 @@ import { createHash } from 'crypto';
 import { getPool } from '../db';
 import logger from '../logger';
 import { gpsDistanceFromTrack } from '../gt3-geo';
+import {
+  RidePhotoBytesRow,
+  RidePhotoMetadataRow,
+  ridePhotoMetadata,
+  sendRidePhotoBytes,
+} from '../gt3-photos';
 
 const gt3PublicLogger = logger.child({ subsystem: 'gt3-public' });
 
@@ -48,6 +54,20 @@ function bumpAccess(shareId: string): void {
     .catch((err: unknown) => gt3PublicLogger.warn({ err, shareId }, 'Failed to bump share access stats'));
 }
 
+async function listPhotosForSharedRide(rideId: string): Promise<Array<Record<string, unknown>>> {
+  const pool = getPool();
+  if (!pool) return [];
+  const result = await pool.query(
+    `SELECT id, captured_at, latitude, longitude, mime_type,
+            octet_length(image_data) AS byte_length, created_at
+     FROM gt3_ride_photos
+     WHERE ride_id = $1
+     ORDER BY captured_at DESC`,
+    [rideId],
+  );
+  return result.rows.map((row: RidePhotoMetadataRow) => ridePhotoMetadata(row));
+}
+
 // GET /gt3/shared/:token — public ride detail
 router.get('/shared/:token', async (req, res) => {
   const pool = getPool();
@@ -77,10 +97,13 @@ router.get('/shared/:token', async (req, res) => {
       }
     }
 
+    const photos = await listPhotosForSharedRide(share.ride_id);
+
     bumpAccess(share.id);
     res.setHeader('Cache-Control', 'private, max-age=60');
     return res.json({
       ride,
+      photos,
       share: {
         expiresAt: share.expires_at,
       },
@@ -116,6 +139,49 @@ router.get('/shared/:token/geojson', async (req, res) => {
     });
   } catch (err) {
     gt3PublicLogger.error({ err }, 'Failed to get shared GeoJSON');
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// GET /gt3/shared/:token/photos — public shared ride photo metadata
+router.get('/shared/:token/photos', async (req, res) => {
+  const pool = getPool();
+  if (!pool) return res.status(503).json({ error: 'Database unavailable' });
+  try {
+    const share = await resolveValidShare(req.params.token);
+    if (!share) return res.status(404).json({ error: 'Share not found or expired' });
+
+    const photos = await listPhotosForSharedRide(share.ride_id);
+    bumpAccess(share.id);
+    res.setHeader('Cache-Control', 'private, max-age=60');
+    return res.json({ photos, rideId: share.ride_id });
+  } catch (err) {
+    gt3PublicLogger.error({ err }, 'Failed to list shared ride photos');
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// GET /gt3/shared/:token/photos/:photoId — public shared ride JPEG bytes
+router.get('/shared/:token/photos/:photoId', async (req, res) => {
+  const pool = getPool();
+  if (!pool) return res.status(503).json({ error: 'Database unavailable' });
+  try {
+    const tokenHash = hashShareToken(req.params.token);
+    const result = await pool.query(
+      `SELECT s.id AS share_id, p.id, p.captured_at, p.mime_type, p.image_data, p.created_at
+       FROM gt3_ride_shares s
+       JOIN gt3_ride_photos p ON p.ride_id = s.ride_id
+       WHERE s.token_hash = $1
+         AND s.revoked_at IS NULL
+         AND (s.expires_at IS NULL OR s.expires_at > NOW())
+         AND p.id = $2`,
+      [tokenHash, req.params.photoId],
+    );
+    if (result.rows.length === 0) return res.status(404).json({ error: 'Photo not found' });
+    bumpAccess(result.rows[0].share_id);
+    return sendRidePhotoBytes(res, result.rows[0] as RidePhotoBytesRow);
+  } catch (err) {
+    gt3PublicLogger.error({ err }, 'Failed to get shared ride photo');
     return res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -357,25 +357,32 @@ router.post('/rides/:id/photos', async (req, res) => {
     return res.status(validation.status).json({ error: validation.error });
   }
 
+  const client = await pool.connect();
   try {
-    const rideResult = await pool.query(
-      'SELECT id FROM gt3_rides WHERE id = $1 AND user_sub = $2',
+    await client.query('BEGIN');
+
+    const rideResult = await client.query(
+      'SELECT id FROM gt3_rides WHERE id = $1 AND user_sub = $2 FOR UPDATE',
       [req.params.id, userSub],
     );
-    if (rideResult.rows.length === 0) return res.status(404).json({ error: 'Ride not found' });
+    if (rideResult.rows.length === 0) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'Ride not found' });
+    }
 
-    const countResult = await pool.query(
+    const countResult = await client.query(
       'SELECT COUNT(*)::int AS count FROM gt3_ride_photos WHERE ride_id = $1 AND user_sub = $2',
       [req.params.id, userSub],
     );
     if ((countResult.rows[0]?.count ?? 0) >= MAX_GT3_PHOTOS_PER_RIDE) {
+      await client.query('ROLLBACK');
       return res.status(409).json({ error: 'Ride photo limit reached' });
     }
 
     const photo = validation.value;
-    const result = await pool.query(
+    const result = await client.query(
       `INSERT INTO gt3_ride_photos (
-         ride_id, user_sub, captured_at, latitude, longitude, mime_type, image_data
+        ride_id, user_sub, captured_at, latitude, longitude, mime_type, image_data
        )
        VALUES ($1,$2,$3,$4,$5,$6,$7)
        RETURNING id`,
@@ -390,11 +397,15 @@ router.post('/rides/:id/photos', async (req, res) => {
       ],
     );
     const photoId = result.rows[0]?.id;
+    await client.query('COMMIT');
     gt3Logger.info({ rideId: req.params.id, photoId, userSub }, 'Stored ride photo');
     return res.json({ ok: true, id: photoId });
   } catch (err) {
+    await client.query('ROLLBACK');
     gt3Logger.error({ err }, 'Failed to store ride photo');
     return res.status(500).json({ error: 'Internal server error' });
+  } finally {
+    client.release();
   }
 });
 
@@ -406,19 +417,21 @@ router.get('/rides/:id/photos', async (req, res) => {
   if (!userSub) return res.status(401).json({ error: 'Unauthorized' });
 
   try {
-    const result = await pool.query(
-      `SELECT r.id AS ride_id, p.id, p.captured_at, p.latitude, p.longitude,
-              p.mime_type, octet_length(p.image_data) AS byte_length, p.created_at
-       FROM gt3_rides r
-       LEFT JOIN gt3_ride_photos p ON p.ride_id = r.id
-       WHERE r.id = $1 AND r.user_sub = $2
-       ORDER BY p.captured_at DESC NULLS LAST`,
+    const rideResult = await pool.query(
+      'SELECT id FROM gt3_rides WHERE id = $1 AND user_sub = $2',
       [req.params.id, userSub],
     );
-    if (result.rows.length === 0) return res.status(404).json({ error: 'Ride not found' });
-    const photos = result.rows
-      .filter((row: RidePhotoMetadataRow & { ride_id: string }) => row.id)
-      .map((row: RidePhotoMetadataRow) => ridePhotoMetadata(row));
+    if (rideResult.rows.length === 0) return res.status(404).json({ error: 'Ride not found' });
+
+    const result = await pool.query(
+      `SELECT id, captured_at, latitude, longitude, mime_type,
+              octet_length(image_data) AS byte_length, created_at
+       FROM gt3_ride_photos
+       WHERE ride_id = $1 AND user_sub = $2
+       ORDER BY captured_at DESC`,
+      [req.params.id, userSub],
+    );
+    const photos = result.rows.map((row: RidePhotoMetadataRow) => ridePhotoMetadata(row));
     return res.json({ photos });
   } catch (err) {
     gt3Logger.error({ err }, 'Failed to list ride photos');

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -7,6 +7,14 @@ import logger from '../logger';
 import { sendGT3PushToStart } from '../apns';
 import { getDeviceTokensByUserAndBundle } from '../push-token-store';
 import { gpsDistanceFromTrack } from '../gt3-geo';
+import {
+  MAX_GT3_PHOTOS_PER_RIDE,
+  RidePhotoBytesRow,
+  RidePhotoMetadataRow,
+  ridePhotoMetadata,
+  sendRidePhotoBytes,
+  validateRidePhotoPayload,
+} from '../gt3-photos';
 
 const influxQuery = new InfluxDBClient({
   url: (process.env.INFLUXDB_URL || '').trim(),
@@ -333,6 +341,110 @@ router.get('/rides/:id', async (req, res) => {
     return res.json(ride);
   } catch (err) {
     gt3Logger.error({ err }, 'Failed to get ride');
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// POST /gt3/rides/:id/photos — attach a JPEG photo to an authenticated user's ride
+router.post('/rides/:id/photos', async (req, res) => {
+  const pool = getPool();
+  if (!pool) return res.status(503).json({ error: 'Database unavailable' });
+  const userSub = req.user?.sub;
+  if (!userSub) return res.status(401).json({ error: 'Unauthorized' });
+
+  const validation = validateRidePhotoPayload(req.body ?? {});
+  if (!validation.ok) {
+    return res.status(validation.status).json({ error: validation.error });
+  }
+
+  try {
+    const rideResult = await pool.query(
+      'SELECT id FROM gt3_rides WHERE id = $1 AND user_sub = $2',
+      [req.params.id, userSub],
+    );
+    if (rideResult.rows.length === 0) return res.status(404).json({ error: 'Ride not found' });
+
+    const countResult = await pool.query(
+      'SELECT COUNT(*)::int AS count FROM gt3_ride_photos WHERE ride_id = $1 AND user_sub = $2',
+      [req.params.id, userSub],
+    );
+    if ((countResult.rows[0]?.count ?? 0) >= MAX_GT3_PHOTOS_PER_RIDE) {
+      return res.status(409).json({ error: 'Ride photo limit reached' });
+    }
+
+    const photo = validation.value;
+    const result = await pool.query(
+      `INSERT INTO gt3_ride_photos (
+         ride_id, user_sub, captured_at, latitude, longitude, mime_type, image_data
+       )
+       VALUES ($1,$2,$3,$4,$5,$6,$7)
+       RETURNING id`,
+      [
+        req.params.id,
+        userSub,
+        photo.capturedAt,
+        photo.latitude,
+        photo.longitude,
+        photo.mimeType,
+        photo.imageData,
+      ],
+    );
+    const photoId = result.rows[0]?.id;
+    gt3Logger.info({ rideId: req.params.id, photoId, userSub }, 'Stored ride photo');
+    return res.json({ ok: true, id: photoId });
+  } catch (err) {
+    gt3Logger.error({ err }, 'Failed to store ride photo');
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// GET /gt3/rides/:id/photos — photo metadata for an authenticated user's ride
+router.get('/rides/:id/photos', async (req, res) => {
+  const pool = getPool();
+  if (!pool) return res.status(503).json({ error: 'Database unavailable' });
+  const userSub = req.user?.sub;
+  if (!userSub) return res.status(401).json({ error: 'Unauthorized' });
+
+  try {
+    const result = await pool.query(
+      `SELECT r.id AS ride_id, p.id, p.captured_at, p.latitude, p.longitude,
+              p.mime_type, octet_length(p.image_data) AS byte_length, p.created_at
+       FROM gt3_rides r
+       LEFT JOIN gt3_ride_photos p ON p.ride_id = r.id
+       WHERE r.id = $1 AND r.user_sub = $2
+       ORDER BY p.captured_at DESC NULLS LAST`,
+      [req.params.id, userSub],
+    );
+    if (result.rows.length === 0) return res.status(404).json({ error: 'Ride not found' });
+    const photos = result.rows
+      .filter((row: RidePhotoMetadataRow & { ride_id: string }) => row.id)
+      .map((row: RidePhotoMetadataRow) => ridePhotoMetadata(row));
+    return res.json({ photos });
+  } catch (err) {
+    gt3Logger.error({ err }, 'Failed to list ride photos');
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// GET /gt3/rides/:id/photos/:photoId — JPEG bytes for an authenticated user's ride photo
+router.get('/rides/:id/photos/:photoId', async (req, res) => {
+  const pool = getPool();
+  if (!pool) return res.status(503).json({ error: 'Database unavailable' });
+  const userSub = req.user?.sub;
+  if (!userSub) return res.status(401).json({ error: 'Unauthorized' });
+
+  try {
+    const result = await pool.query(
+      `SELECT p.id, p.captured_at, p.mime_type, p.image_data, p.created_at
+       FROM gt3_ride_photos p
+       JOIN gt3_rides r ON r.id = p.ride_id
+       WHERE p.id = $1 AND p.ride_id = $2 AND r.user_sub = $3`,
+      [req.params.photoId, req.params.id, userSub],
+    );
+    if (result.rows.length === 0) return res.status(404).json({ error: 'Photo not found' });
+    return sendRidePhotoBytes(res, result.rows[0] as RidePhotoBytesRow);
+  } catch (err) {
+    gt3Logger.error({ err }, 'Failed to get ride photo');
     return res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -100,6 +100,18 @@ export async function createServer(): Promise<Express> {
     express.json({ limit: '10mb' }),
     express.urlencoded({ extended: true }),
   );
+  app.use((
+    err: Error & { type?: string; status?: number },
+    _req: express.Request,
+    res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    if (err.type === 'entity.too.large' || err.status === 413) {
+      res.status(413).json({ error: 'Request body too large' });
+      return;
+    }
+    next(err);
+  });
 
   // PG-backed session store (for server-side session tracking/revocation)
   const PgStore = connectPgSimple(session);


### PR DESCRIPTION
## Summary
- add GT3 ride photo persistence and authenticated upload/read endpoints
- expose share-safe photo metadata and JPEG bytes for shared rides
- validate JPEG payloads, ownership/share access, size/count limits, and safe response headers

## Validation
- npm run lint
- npm run build
- npm test -- --runInBand src/__tests__/gt3-photos.test.ts src/__tests__/gt3-share.test.ts

Note: attempted the full Jest suite with `npm test -- --runInBand`, but it stalled in the existing `server.test.ts` path and was stopped after the targeted GT3 tests, lint, and build passed.