### PR TITLE
Support GT3 ride health backfill

### DIFF
--- a/src/__tests__/gt3-photos.test.ts
+++ b/src/__tests__/gt3-photos.test.ts
@@ -207,6 +207,40 @@ describe('GT3 ride photos', () => {
     });
   });
 
+  describe('PATCH /gt3/rides/:id/health', () => {
+    it('merges ride health data and backfills timestamped heart-rate samples', async () => {
+      mockClientQuery
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ id: RIDE_ID, health_data: { existing: true } }] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const timestamp = '2026-05-17T15:00:00.000Z';
+      const res = await request(buildApp(USER_SUB))
+        .patch(`/gt3/rides/${RIDE_ID}/health`)
+        .send({
+          healthData: { averageHeartRate: 132, maxHeartRate: 155, activeCalories: 210.5 },
+          heartRateSamples: [{ timestamp, heartRate: 144 }],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true, updatedSamples: 1 });
+      expect(mockClientQuery.mock.calls[1][0]).toContain('FOR UPDATE');
+      expect(mockClientQuery.mock.calls[2][1]).toEqual([
+        {
+          existing: true,
+          averageHeartRate: 132,
+          maxHeartRate: 155,
+          activeCalories: 210.5,
+        },
+        RIDE_ID,
+      ]);
+      expect(mockClientQuery.mock.calls[3][1]).toEqual([144, RIDE_ID, timestamp]);
+      expect(mockClientQuery.mock.calls[4][0]).toBe('COMMIT');
+    });
+  });
+
   describe('GET /gt3/rides/:id/photos', () => {
     it('returns metadata without image bytes', async () => {
       mockQuery

--- a/src/__tests__/gt3-photos.test.ts
+++ b/src/__tests__/gt3-photos.test.ts
@@ -299,6 +299,58 @@ describe('GT3 ride photos', () => {
       expect(res.status).toBe(413);
       expect(mockClientQuery).not.toHaveBeenCalled();
     });
+
+    it('rejects oversized health data objects', async () => {
+      const healthData = Object.fromEntries(
+        Array.from({ length: 21 }, (_value, index) => [`metric${index}`, index]),
+      );
+
+      const res = await request(buildApp(USER_SUB))
+        .patch(`/gt3/rides/${RIDE_ID}/health`)
+        .send({ healthData });
+
+      expect(res.status).toBe(413);
+      expect(mockClientQuery).not.toHaveBeenCalled();
+    });
+
+    it('backfills timestamped heart-rate samples when health data is omitted', async () => {
+      mockClientQuery
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ id: RIDE_ID, health_data: null }] })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const timestamp = '2026-05-17T15:00:00.000Z';
+      const res = await request(buildApp(USER_SUB))
+        .patch(`/gt3/rides/${RIDE_ID}/health`)
+        .send({ heartRateSamples: [{ timestamp, heartRate: 144 }] });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true, updatedSamples: 1 });
+      expect(mockClientQuery.mock.calls[2][0]).toContain('WITH input');
+      expect(mockClientQuery.mock.calls[2][1]).toEqual([timestamp, 144, RIDE_ID]);
+      expect(mockClientQuery.mock.calls[3][0]).toBe('COMMIT');
+    });
+
+    it('rolls back health backfill transactions on database errors', async () => {
+      mockClientQuery
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ id: RIDE_ID, health_data: null }] })
+        .mockRejectedValueOnce(new Error('sample update failed'))
+        .mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(buildApp(USER_SUB))
+        .patch(`/gt3/rides/${RIDE_ID}/health`)
+        .send({
+          heartRateSamples: [{
+            timestamp: '2026-05-17T15:00:00.000Z',
+            heartRate: 144,
+          }],
+        });
+
+      expect(res.status).toBe(500);
+      expect(mockClientQuery.mock.calls[3][0]).toBe('ROLLBACK');
+    });
   });
 
   describe('GET /gt3/rides/:id/photos', () => {

--- a/src/__tests__/gt3-photos.test.ts
+++ b/src/__tests__/gt3-photos.test.ts
@@ -228,16 +228,76 @@ describe('GT3 ride photos', () => {
       expect(res.body).toEqual({ ok: true, updatedSamples: 1 });
       expect(mockClientQuery.mock.calls[1][0]).toContain('FOR UPDATE');
       expect(mockClientQuery.mock.calls[2][1]).toEqual([
-        {
+        JSON.stringify({
           existing: true,
           averageHeartRate: 132,
           maxHeartRate: 155,
           activeCalories: 210.5,
-        },
+        }),
         RIDE_ID,
       ]);
-      expect(mockClientQuery.mock.calls[3][1]).toEqual([144, RIDE_ID, timestamp]);
+      expect(mockClientQuery.mock.calls[3][0]).toContain('WITH input');
+      expect(mockClientQuery.mock.calls[3][1]).toEqual([timestamp, 144, RIDE_ID]);
       expect(mockClientQuery.mock.calls[4][0]).toBe('COMMIT');
+    });
+
+    it('requires an authenticated OIDC user for health backfill', async () => {
+      const res = await request(buildApp(null))
+        .patch(`/gt3/rides/${RIDE_ID}/health`)
+        .send({ heartRateSamples: [] });
+
+      expect(res.status).toBe(401);
+      expect(mockClientQuery).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when health backfill ride is not owned by the user', async () => {
+      mockClientQuery
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(buildApp(USER_SUB))
+        .patch(`/gt3/rides/${RIDE_ID}/health`)
+        .send({ heartRateSamples: [] });
+
+      expect(res.status).toBe(404);
+      expect(mockClientQuery.mock.calls[2][0]).toBe('ROLLBACK');
+    });
+
+    it('skips invalid heart-rate samples without failing the health patch', async () => {
+      mockClientQuery
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ id: RIDE_ID, health_data: null }] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(buildApp(USER_SUB))
+        .patch(`/gt3/rides/${RIDE_ID}/health`)
+        .send({
+          heartRateSamples: [
+            { timestamp: 'not-a-date', heartRate: 144 },
+            { timestamp: '2026-05-17T15:00:00.000Z', heartRate: 'wat' },
+            { timestamp: '2026-05-17T15:01:00.000Z', heartRate: 0 },
+          ],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true, updatedSamples: 0 });
+      expect(mockClientQuery).toHaveBeenCalledTimes(3);
+      expect(mockClientQuery.mock.calls[2][0]).toBe('COMMIT');
+    });
+
+    it('rejects oversized health backfill batches', async () => {
+      const heartRateSamples = Array.from({ length: 5_001 }, (_, index) => ({
+        timestamp: new Date(1_768_000_000_000 + index).toISOString(),
+        heartRate: 120,
+      }));
+
+      const res = await request(buildApp(USER_SUB))
+        .patch(`/gt3/rides/${RIDE_ID}/health`)
+        .send({ heartRateSamples });
+
+      expect(res.status).toBe(413);
+      expect(mockClientQuery).not.toHaveBeenCalled();
     });
   });
 

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -27,6 +27,7 @@ const gt3Logger = logger.child({ subsystem: 'gt3' });
 
 const router = Router();
 const MAX_GT3_HEALTH_SAMPLES = 5_000;
+const MAX_GT3_HEALTH_DATA_KEYS = 20;
 
 function finiteNonNegativeNumber(value: unknown): number | undefined {
   const numberValue = Number(value);
@@ -48,6 +49,13 @@ function sanitizeRideHealthData(healthData: unknown): Record<string, number> | n
     if (value !== undefined) sanitized[key] = value;
   });
   return Object.keys(sanitized).length > 0 ? sanitized : null;
+}
+
+function hasOversizedRideHealthData(healthData: unknown): boolean {
+  return !!healthData
+    && typeof healthData === 'object'
+    && !Array.isArray(healthData)
+    && Object.keys(healthData).length > MAX_GT3_HEALTH_DATA_KEYS;
 }
 
 // POST /gt3/telemetry — batch telemetry samples → InfluxDB
@@ -312,6 +320,9 @@ router.patch('/rides/:id/health', async (req, res) => {
     const samples = Array.isArray(heartRateSamples) ? heartRateSamples : [];
     if (samples.length > MAX_GT3_HEALTH_SAMPLES) {
       return res.status(413).json({ error: 'Too many heart-rate samples' });
+    }
+    if (hasOversizedRideHealthData(healthData)) {
+      return res.status(413).json({ error: 'Too many health data fields' });
     }
 
     await client.query('BEGIN');

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -26,6 +26,7 @@ const influxQuery = new InfluxDBClient({
 const gt3Logger = logger.child({ subsystem: 'gt3' });
 
 const router = Router();
+const MAX_GT3_HEALTH_SAMPLES = 5_000;
 
 // POST /gt3/telemetry — batch telemetry samples → InfluxDB
 router.post('/telemetry', async (req, res) => {
@@ -287,6 +288,9 @@ router.patch('/rides/:id/health', async (req, res) => {
   try {
     const { healthData, heartRateSamples } = req.body ?? {};
     const samples = Array.isArray(heartRateSamples) ? heartRateSamples : [];
+    if (samples.length > MAX_GT3_HEALTH_SAMPLES) {
+      return res.status(413).json({ error: 'Too many heart-rate samples' });
+    }
 
     await client.query('BEGIN');
     const rideResult = await client.query(
@@ -302,28 +306,51 @@ router.patch('/rides/:id/health', async (req, res) => {
       const existing = rideResult.rows[0].health_data ?? {};
       await client.query(
         'UPDATE gt3_rides SET health_data = $1 WHERE id = $2',
-        [{ ...existing, ...healthData }, req.params.id],
+        [JSON.stringify({ ...existing, ...healthData }), req.params.id],
       );
     }
 
     const validSamples = samples.flatMap((sample) => {
       const heartRate = Number(sample?.heartRate);
       const timestamp = sample?.timestamp ? new Date(sample.timestamp) : null;
-      if (!timestamp || Number.isNaN(timestamp.getTime()) || heartRate <= 0) return [];
+      if (!timestamp
+        || Number.isNaN(timestamp.getTime())
+        || !Number.isFinite(heartRate)
+        || heartRate <= 0) {
+        return [];
+      }
       return [{ heartRate: Math.round(heartRate), timestamp: timestamp.toISOString() }];
     });
-    const updatedSamples = await validSamples.reduce(async (chain, sample) => {
-      const count = await chain;
-      const result = await client.query(
-        `UPDATE gt3_samples
-         SET heart_rate = $1
-         WHERE ride_id = $2
-           AND timestamp BETWEEN $3::timestamptz - INTERVAL '750 milliseconds'
-                         AND $3::timestamptz + INTERVAL '750 milliseconds'`,
-        [sample.heartRate, req.params.id, sample.timestamp],
-      );
-      return count + (result.rowCount ?? 0);
-    }, Promise.resolve(0));
+    const sampleValues = validSamples.reduce((values, sample) => {
+      values.push(sample.timestamp, sample.heartRate);
+      return values;
+    }, [] as Array<string | number>);
+    const valuesSql = validSamples.map((_sample, index) => {
+      const p = index * 2 + 1;
+      return `($${p}::timestamptz, $${p + 1}::integer)`;
+    });
+    const updatedSamples = validSamples.length > 0 ? (await client.query(
+      `WITH input(ts, heart_rate) AS (VALUES ${valuesSql.join(',')}),
+       nearest AS (
+         SELECT DISTINCT ON (sample_match.id) sample_match.id, input.heart_rate
+         FROM input
+         CROSS JOIN LATERAL (
+           SELECT id, ABS(EXTRACT(EPOCH FROM (timestamp - input.ts))) AS delta
+           FROM gt3_samples
+           WHERE ride_id = $${sampleValues.length + 1}
+             AND timestamp BETWEEN input.ts - INTERVAL '750 milliseconds'
+                           AND input.ts + INTERVAL '750 milliseconds'
+           ORDER BY delta
+           LIMIT 1
+         ) AS sample_match
+         ORDER BY sample_match.id, sample_match.delta
+       )
+       UPDATE gt3_samples AS samples
+       SET heart_rate = nearest.heart_rate
+       FROM nearest
+       WHERE samples.id = nearest.id`,
+      [...sampleValues, req.params.id],
+    )).rowCount ?? 0 : 0;
 
     await client.query('COMMIT');
     gt3Logger.info({ rideId: req.params.id, updatedSamples }, 'Updated ride health data');

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -28,6 +28,28 @@ const gt3Logger = logger.child({ subsystem: 'gt3' });
 const router = Router();
 const MAX_GT3_HEALTH_SAMPLES = 5_000;
 
+function finiteNonNegativeNumber(value: unknown): number | undefined {
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) && numberValue >= 0 ? numberValue : undefined;
+}
+
+function sanitizeRideHealthData(healthData: unknown): Record<string, number> | null {
+  if (!healthData || typeof healthData !== 'object' || Array.isArray(healthData)) return null;
+  const source = healthData as Record<string, unknown>;
+  const sanitized: Record<string, number> = {};
+  [
+    'avgHeartRate',
+    'averageHeartRate',
+    'maxHeartRate',
+    'totalCalories',
+    'activeCalories',
+  ].forEach((key) => {
+    const value = finiteNonNegativeNumber(source[key]);
+    if (value !== undefined) sanitized[key] = value;
+  });
+  return Object.keys(sanitized).length > 0 ? sanitized : null;
+}
+
 // POST /gt3/telemetry — batch telemetry samples → InfluxDB
 router.post('/telemetry', async (req, res) => {
   try {
@@ -302,11 +324,12 @@ router.patch('/rides/:id/health', async (req, res) => {
       return res.status(404).json({ error: 'Ride not found' });
     }
 
-    if (healthData && typeof healthData === 'object') {
+    const sanitizedHealthData = sanitizeRideHealthData(healthData);
+    if (sanitizedHealthData) {
       const existing = rideResult.rows[0].health_data ?? {};
       await client.query(
         'UPDATE gt3_rides SET health_data = $1 WHERE id = $2',
-        [JSON.stringify({ ...existing, ...healthData }), req.params.id],
+        [JSON.stringify({ ...existing, ...sanitizedHealthData }), req.params.id],
       );
     }
 

--- a/src/routes/gt3.routes.ts
+++ b/src/routes/gt3.routes.ts
@@ -169,8 +169,9 @@ router.post('/ride', async (req, res) => {
       gear_mode: r.primaryGearMode ?? r.gearMode ?? 0,
     };
     if (r.healthData) {
-      rideFields.avg_heart_rate = r.healthData.avgHeartRate ?? 0;
-      rideFields.total_calories = r.healthData.totalCalories ?? 0;
+      rideFields.avg_heart_rate = r.healthData.avgHeartRate ?? r.healthData.averageHeartRate ?? 0;
+      rideFields.max_heart_rate = r.healthData.maxHeartRate ?? 0;
+      rideFields.total_calories = r.healthData.totalCalories ?? r.healthData.activeCalories ?? 0;
     }
     if (r.weather) {
       rideFields.weather_temp = r.weather.temp ?? 0;
@@ -270,6 +271,67 @@ router.post('/ride', async (req, res) => {
     const detail = err instanceof Error ? err.message : String(err);
     gt3Logger.error({ err }, 'Failed to store ride');
     return res.status(500).json({ error: 'Internal server error', detail });
+  } finally {
+    client.release();
+  }
+});
+
+// PATCH /gt3/rides/:id/health — backfill ride health summary and timestamped HR samples
+router.patch('/rides/:id/health', async (req, res) => {
+  const pool = getPool();
+  if (!pool) return res.status(503).json({ error: 'Database unavailable' });
+  const userSub = req.user?.sub;
+  if (!userSub) return res.status(401).json({ error: 'Unauthorized' });
+
+  const client = await pool.connect();
+  try {
+    const { healthData, heartRateSamples } = req.body ?? {};
+    const samples = Array.isArray(heartRateSamples) ? heartRateSamples : [];
+
+    await client.query('BEGIN');
+    const rideResult = await client.query(
+      'SELECT id, health_data FROM gt3_rides WHERE id = $1 AND user_sub = $2 FOR UPDATE',
+      [req.params.id, userSub],
+    );
+    if (rideResult.rows.length === 0) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'Ride not found' });
+    }
+
+    if (healthData && typeof healthData === 'object') {
+      const existing = rideResult.rows[0].health_data ?? {};
+      await client.query(
+        'UPDATE gt3_rides SET health_data = $1 WHERE id = $2',
+        [{ ...existing, ...healthData }, req.params.id],
+      );
+    }
+
+    const validSamples = samples.flatMap((sample) => {
+      const heartRate = Number(sample?.heartRate);
+      const timestamp = sample?.timestamp ? new Date(sample.timestamp) : null;
+      if (!timestamp || Number.isNaN(timestamp.getTime()) || heartRate <= 0) return [];
+      return [{ heartRate: Math.round(heartRate), timestamp: timestamp.toISOString() }];
+    });
+    const updatedSamples = await validSamples.reduce(async (chain, sample) => {
+      const count = await chain;
+      const result = await client.query(
+        `UPDATE gt3_samples
+         SET heart_rate = $1
+         WHERE ride_id = $2
+           AND timestamp BETWEEN $3::timestamptz - INTERVAL '750 milliseconds'
+                         AND $3::timestamptz + INTERVAL '750 milliseconds'`,
+        [sample.heartRate, req.params.id, sample.timestamp],
+      );
+      return count + (result.rowCount ?? 0);
+    }, Promise.resolve(0));
+
+    await client.query('COMMIT');
+    gt3Logger.info({ rideId: req.params.id, updatedSamples }, 'Updated ride health data');
+    return res.json({ ok: true, updatedSamples });
+  } catch (err) {
+    await client.query('ROLLBACK');
+    gt3Logger.error({ err }, 'Failed to update ride health data');
+    return res.status(500).json({ error: 'Internal server error' });
   } finally {
     client.release();
   }


### PR DESCRIPTION
## Summary
- accept average/max HR and active calories in GT3 ride health data
- add PATCH /gt3/rides/:id/health for timestamped HR sample backfill
- cover the health patch route in GT3 route tests

## Validation
- npm run lint --prefix ../fluxhaus-server
- npm run build --prefix ../fluxhaus-server
- npm test --prefix ../fluxhaus-server -- --runInBand src/__tests__/gt3-share.test.ts src/__tests__/gt3-photos.test.ts

Note: the full local npm test run hung in src/__tests__/mcp-server.test.ts before reaching GT3 tests; targeted GT3 tests passed.