### PR TITLE
feat: categorize memories and add conversational memory management

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ The server uses PostgreSQL for:
 - **Session storage** (`session` table) — browser login sessions
 - **OAuth tokens** (`oauth_tokens` table) — Miele and HomeConnect tokens
 - **User preferences** (`user_preferences` table) — includes memory preferences and default calendar selection
+- **User memories** (`user_memories` table) — durable facts the assistant remembers about each user, grouped by `category` (`project`, `possession`, `wishlist`, `preference`, `fact`); content is encrypted at rest. The assistant captures these proactively as you chat and can list, add, update, delete, or clear them on request (`list_memories`, `save_memory`, `update_memory`, `delete_memory`, `delete_all_memories` tools), in addition to the `/memories` REST endpoints.
 
 ```
 POSTGRES_URL=postgresql://fluxhaus:password@localhost:5432/fluxhaus

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The server uses PostgreSQL for:
 - **Session storage** (`session` table) — browser login sessions
 - **OAuth tokens** (`oauth_tokens` table) — Miele and HomeConnect tokens
 - **User preferences** (`user_preferences` table) — includes memory preferences and default calendar selection
-- **User memories** (`user_memories` table) — durable facts the assistant remembers about each user, grouped by `category` (`project`, `possession`, `wishlist`, `preference`, `fact`); content is encrypted at rest. The assistant captures these proactively as you chat and can list, add, update, delete, or clear them on request (`list_memories`, `save_memory`, `update_memory`, `delete_memory`, `delete_all_memories` tools), in addition to the `/memories` REST endpoints.
+- **User memories** (`user_memories` table) — durable facts the assistant remembers about each user, grouped by `category` (`project`, `possession`, `wishlist`, `preference`, `fact`); content is encrypted at rest. The assistant captures these proactively as you chat and can fully manage them through chat tools — list, add, update, delete, or clear (`list_memories`, `save_memory`, `update_memory`, `delete_memory`, `delete_all_memories`). The REST API exposes a subset: `GET /memories` (list) and `DELETE /memories/:id` / `DELETE /memories` (delete one or clear all).
 
 ```
 POSTGRES_URL=postgresql://fluxhaus:password@localhost:5432/fluxhaus

--- a/src/__tests__/memory.test.ts
+++ b/src/__tests__/memory.test.ts
@@ -1,5 +1,6 @@
 import {
-  buildMemoryPrompt, deleteAllMemories, deleteMemory, listMemories, saveMemory, updateMemory,
+  MAX_MEMORIES_IN_PROMPT, buildMemoryPrompt, deleteAllMemories, deleteMemory,
+  listMemories, saveMemory, updateMemory,
 } from '../memory';
 
 jest.mock('../db', () => ({
@@ -218,6 +219,22 @@ describe('memory', () => {
       expect(prompt).toContain('save_memory');
       expect(prompt).toContain('delete_memory');
       expect(prompt).toContain('id:mem-1');
+    });
+
+    it('caps embedded memories at MAX_MEMORIES_IN_PROMPT and notes truncation', async () => {
+      const total = MAX_MEMORIES_IN_PROMPT + 5;
+      const rows = Array.from({ length: total }, (_, i) => ({
+        id: `mem-${i}`,
+        content: `enc:memory ${i}`,
+        category: 'fact',
+        created_at: '2026-01-01T00:00:00Z',
+      }));
+      mockPool.query.mockResolvedValue({ rows });
+      const prompt = await buildMemoryPrompt('user-1');
+      expect(prompt).toContain(`${MAX_MEMORIES_IN_PROMPT} most recent of ${total}`);
+      // Oldest entries (mem-0..mem-4) are dropped; the newest is retained.
+      expect(prompt).not.toContain('[id:mem-0]');
+      expect(prompt).toContain(`[id:mem-${total - 1}]`);
     });
   });
 });

--- a/src/__tests__/memory.test.ts
+++ b/src/__tests__/memory.test.ts
@@ -119,6 +119,22 @@ describe('memory', () => {
       expect(sql).not.toContain('AND category');
       expect(params).toEqual(['user-1']);
     });
+
+    it('treats null or empty category as no filter', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+      await listMemories('user-1', '');
+      await listMemories('user-1', null as unknown as string);
+      expect(mockPool.query.mock.calls[0][0]).not.toContain('AND category');
+      expect(mockPool.query.mock.calls[0][1]).toEqual(['user-1']);
+      expect(mockPool.query.mock.calls[1][0]).not.toContain('AND category');
+      expect(mockPool.query.mock.calls[1][1]).toEqual(['user-1']);
+    });
+
+    it('orders by created_at with a stable id tie-breaker', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+      await listMemories('user-1');
+      expect(mockPool.query.mock.calls[0][0]).toContain('ORDER BY created_at, id');
+    });
   });
 
   describe('deleteMemory', () => {

--- a/src/__tests__/memory.test.ts
+++ b/src/__tests__/memory.test.ts
@@ -1,5 +1,5 @@
 import {
-  buildMemoryPrompt, deleteAllMemories, deleteMemory, listMemories, saveMemory,
+  buildMemoryPrompt, deleteAllMemories, deleteMemory, listMemories, saveMemory, updateMemory,
 } from '../memory';
 
 jest.mock('../db', () => ({
@@ -35,7 +35,7 @@ describe('memory', () => {
         .rejects.toThrow('Database not available');
     });
 
-    it('encrypts and inserts memory', async () => {
+    it('encrypts and inserts memory with default category', async () => {
       mockPool.query.mockResolvedValue({
         rows: [{ id: 'mem-1', created_at: '2026-01-01T00:00:00Z' }],
       });
@@ -43,9 +43,28 @@ describe('memory', () => {
       expect(mem).toEqual({
         id: 'mem-1',
         content: 'likes cats',
+        category: 'fact',
         createdAt: '2026-01-01T00:00:00Z',
       });
-      expect(mockPool.query.mock.calls[0][1]).toEqual(['user-1', 'enc:likes cats']);
+      expect(mockPool.query.mock.calls[0][1]).toEqual(['user-1', 'enc:likes cats', 'fact']);
+    });
+
+    it('stores the provided category', async () => {
+      mockPool.query.mockResolvedValue({
+        rows: [{ id: 'mem-2', created_at: '2026-01-01T00:00:00Z' }],
+      });
+      const mem = await saveMemory('user-1', 'building a deck', 'project');
+      expect(mem.category).toBe('project');
+      expect(mockPool.query.mock.calls[0][1]).toEqual(['user-1', 'enc:building a deck', 'project']);
+    });
+
+    it('falls back to fact for unknown categories', async () => {
+      mockPool.query.mockResolvedValue({
+        rows: [{ id: 'mem-3', created_at: '2026-01-01T00:00:00Z' }],
+      });
+      const mem = await saveMemory('user-1', 'something', 'nonsense');
+      expect(mem.category).toBe('fact');
+      expect(mockPool.query.mock.calls[0][1]).toEqual(['user-1', 'enc:something', 'fact']);
     });
   });
 
@@ -56,17 +75,32 @@ describe('memory', () => {
       expect(result).toEqual([]);
     });
 
-    it('decrypts and returns memories', async () => {
+    it('decrypts and returns memories with category', async () => {
       mockPool.query.mockResolvedValue({
         rows: [
-          { id: 'mem-1', content: 'enc:likes cats', created_at: '2026-01-01T00:00:00Z' },
-          { id: 'mem-2', content: 'enc:prefers Celsius', created_at: '2026-01-02T00:00:00Z' },
+          {
+            id: 'mem-1', content: 'enc:likes cats', category: 'preference', created_at: '2026-01-01T00:00:00Z',
+          },
+          {
+            id: 'mem-2', content: 'enc:prefers Celsius', category: 'preference', created_at: '2026-01-02T00:00:00Z',
+          },
         ],
       });
       const result = await listMemories('user-1');
       expect(result).toHaveLength(2);
       expect(result[0].content).toBe('likes cats');
+      expect(result[0].category).toBe('preference');
       expect(result[1].content).toBe('prefers Celsius');
+    });
+
+    it('normalizes a missing category to fact', async () => {
+      mockPool.query.mockResolvedValue({
+        rows: [
+          { id: 'mem-1', content: 'enc:legacy note', created_at: '2026-01-01T00:00:00Z' },
+        ],
+      });
+      const result = await listMemories('user-1');
+      expect(result[0].category).toBe('fact');
     });
   });
 
@@ -84,6 +118,62 @@ describe('memory', () => {
     });
   });
 
+  describe('updateMemory', () => {
+    it('updates content and category', async () => {
+      mockPool.query.mockResolvedValue({
+        rowCount: 1,
+        rows: [{
+          id: 'mem-1', content: 'enc:owns a GT3', category: 'possession', created_at: '2026-01-01T00:00:00Z',
+        }],
+      });
+      const result = await updateMemory('user-1', 'mem-1', {
+        content: 'owns a GT3',
+        category: 'possession',
+      });
+      expect(result).toEqual({
+        id: 'mem-1',
+        content: 'owns a GT3',
+        category: 'possession',
+        createdAt: '2026-01-01T00:00:00Z',
+      });
+      const [sql, params] = mockPool.query.mock.calls[0];
+      expect(sql).toContain('UPDATE user_memories SET content = $1, category = $2');
+      expect(params).toEqual(['enc:owns a GT3', 'possession', 'mem-1', 'user-1']);
+    });
+
+    it('updates only the category', async () => {
+      mockPool.query.mockResolvedValue({
+        rowCount: 1,
+        rows: [{
+          id: 'mem-1', content: 'enc:espresso machine', category: 'possession', created_at: '2026-01-01T00:00:00Z',
+        }],
+      });
+      const result = await updateMemory('user-1', 'mem-1', { category: 'possession' });
+      expect(result?.category).toBe('possession');
+      const [sql, params] = mockPool.query.mock.calls[0];
+      expect(sql).toContain('SET category = $1');
+      expect(params).toEqual(['possession', 'mem-1', 'user-1']);
+    });
+
+    it('returns null when the memory does not exist', async () => {
+      mockPool.query.mockResolvedValue({ rowCount: 0, rows: [] });
+      const result = await updateMemory('user-1', 'mem-99', { content: 'x' });
+      expect(result).toBeNull();
+    });
+
+    it('returns the current memory unchanged when no fields are provided', async () => {
+      mockPool.query.mockResolvedValue({
+        rowCount: 1,
+        rows: [{
+          id: 'mem-1', content: 'enc:likes cats', category: 'preference', created_at: '2026-01-01T00:00:00Z',
+        }],
+      });
+      const result = await updateMemory('user-1', 'mem-1', {});
+      expect(result?.content).toBe('likes cats');
+      expect(mockPool.query.mock.calls[0][0]).toContain('SELECT');
+    });
+  });
+
   describe('deleteAllMemories', () => {
     it('returns count of deleted', async () => {
       mockPool.query.mockResolvedValue({ rowCount: 5 });
@@ -93,20 +183,38 @@ describe('memory', () => {
   });
 
   describe('buildMemoryPrompt', () => {
-    it('returns empty string when no memories', async () => {
+    it('returns a proactive capture directive when there are no memories', async () => {
       mockPool.query.mockResolvedValue({ rows: [] });
       const prompt = await buildMemoryPrompt('user-1');
-      expect(prompt).toBe('');
+      expect(prompt).toContain('save_memory');
+      expect(prompt).toContain('without being asked');
+      expect(prompt).toContain('no saved memories');
     });
 
-    it('returns formatted prompt with memories', async () => {
+    it('groups memories by category', async () => {
       mockPool.query.mockResolvedValue({
         rows: [
-          { id: 'mem-1', content: 'enc:likes cats', created_at: '2026-01-01T00:00:00Z' },
+          {
+            id: 'mem-1', content: 'enc:building a deck', category: 'project', created_at: '2026-01-01T00:00:00Z',
+          },
+          {
+            id: 'mem-2', content: 'enc:owns a GT3', category: 'possession', created_at: '2026-01-02T00:00:00Z',
+          },
+          {
+            id: 'mem-3',
+            content: 'enc:wants an espresso machine',
+            category: 'wishlist',
+            created_at: '2026-01-03T00:00:00Z',
+          },
         ],
       });
       const prompt = await buildMemoryPrompt('user-1');
-      expect(prompt).toContain('likes cats');
+      expect(prompt).toContain("Projects they're working on:");
+      expect(prompt).toContain('building a deck');
+      expect(prompt).toContain('Things they own:');
+      expect(prompt).toContain('owns a GT3');
+      expect(prompt).toContain("Things they're thinking about buying:");
+      expect(prompt).toContain('wants an espresso machine');
       expect(prompt).toContain('save_memory');
       expect(prompt).toContain('delete_memory');
       expect(prompt).toContain('id:mem-1');

--- a/src/__tests__/memory.test.ts
+++ b/src/__tests__/memory.test.ts
@@ -103,6 +103,22 @@ describe('memory', () => {
       const result = await listMemories('user-1');
       expect(result[0].category).toBe('fact');
     });
+
+    it('pushes the category filter down into the SQL query', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+      await listMemories('user-1', 'project');
+      const [sql, params] = mockPool.query.mock.calls[0];
+      expect(sql).toContain('AND category = $2');
+      expect(params).toEqual(['user-1', 'project']);
+    });
+
+    it('does not filter by category when none is given', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+      await listMemories('user-1');
+      const [sql, params] = mockPool.query.mock.calls[0];
+      expect(sql).not.toContain('AND category');
+      expect(params).toEqual(['user-1']);
+    });
   });
 
   describe('deleteMemory', () => {
@@ -184,6 +200,13 @@ describe('memory', () => {
   });
 
   describe('buildMemoryPrompt', () => {
+    it('returns an empty string when the database is unavailable', async () => {
+      getPool.mockReturnValue(null);
+      const prompt = await buildMemoryPrompt('user-1');
+      expect(prompt).toBe('');
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+
     it('returns a proactive capture directive when there are no memories', async () => {
       mockPool.query.mockResolvedValue({ rows: [] });
       const prompt = await buildMemoryPrompt('user-1');

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -415,7 +415,7 @@ describe('Server', () => {
         [],
         undefined,
         undefined,
-        undefined,
+        expect.stringContaining('long-term memory'),
         'test-user-123',
       );
       expect(mockedSynthesizeSpeech).toHaveBeenCalledWith('Lights are on.');
@@ -441,7 +441,7 @@ describe('Server', () => {
         [],
         undefined,
         undefined,
-        undefined,
+        expect.stringContaining('long-term memory'),
         'test-user-123',
       );
     });

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -9,6 +9,7 @@ import HomeConnect from '../homeconnect';
 import transcribeAudio from '../stt';
 import synthesizeSpeech from '../tts';
 import { executeAICommand } from '../ai-command';
+import { getPool } from '../db';
 
 // Mock dependencies
 jest.mock('fs');
@@ -385,6 +386,18 @@ describe('Server', () => {
       mockedExecuteAICommand.mockResolvedValue('Lights are on.');
     });
 
+    // Some tests below enable the memory path by giving getPool a live pool;
+    // restore the default (no DB) afterwards so it never leaks into other tests.
+    afterEach(() => {
+      jest.mocked(getPool).mockReturnValue(null);
+    });
+
+    const enableMemoryPool = () => {
+      jest.mocked(getPool).mockReturnValue({
+        query: jest.fn().mockResolvedValue({ rows: [] }),
+      } as never);
+    };
+
     it('returns 403 for non-admin', async () => {
       await request(app)
         .post('/voice')
@@ -402,6 +415,7 @@ describe('Server', () => {
     });
 
     it('processes text input and returns audio/mpeg', async () => {
+      enableMemoryPool();
       const response = await request(app)
         .post('/voice')
         .set('Authorization', oidcAuthHeader)
@@ -424,6 +438,7 @@ describe('Server', () => {
     });
 
     it('processes base64 audio input via STT then returns audio/mpeg', async () => {
+      enableMemoryPool();
       const fakeAudio = Buffer.from('fake audio bytes').toString('base64');
       await request(app)
         .post('/voice')

--- a/src/ai-command.ts
+++ b/src/ai-command.ts
@@ -1164,10 +1164,18 @@ const TOOL_DEFINITIONS: ToolDefinition[] = [
     name: 'delete_all_memories',
     description: 'Delete ALL of the user\'s memories at once (a full cleanup). This is destructive '
       + 'and cannot be undone — only use it after the user explicitly confirms they want to erase '
-      + 'everything you remember about them.',
+      + 'everything you remember about them. You must pass confirm: true, and only set it once the '
+      + 'user has clearly confirmed.',
     parameters: {
       type: 'object',
-      properties: {},
+      properties: {
+        confirm: {
+          type: 'boolean',
+          description: 'Must be true to proceed. Set this only after the user has explicitly '
+            + 'confirmed they want to permanently delete all of their memories.',
+        },
+      },
+      required: ['confirm'],
     },
   },
 ];
@@ -1886,6 +1894,10 @@ async function executeToolInner(
   }
   case 'delete_all_memories': {
     if (!userSub) return 'Memory not available — user not authenticated';
+    if (args.confirm !== true) {
+      return 'Refused: deleting all memories is irreversible and requires explicit confirmation. '
+        + 'Confirm with the user first, then call again with confirm set to true.';
+    }
     const count = await deleteAllMemories(userSub);
     return `Deleted ${count} ${count === 1 ? 'memory' : 'memories'}`;
   }

--- a/src/ai-command.ts
+++ b/src/ai-command.ts
@@ -3,7 +3,9 @@ import OpenAI, { AzureOpenAI } from 'openai';
 import { Readability } from '@mozilla/readability';
 import { parseHTML } from 'linkedom';
 import { FluxHausServices } from './services';
-import { deleteMemory, saveMemory } from './memory';
+import {
+  deleteAllMemories, deleteMemory, listMemories, normalizeCategory, saveMemory, updateMemory,
+} from './memory';
 import logger from './logger';
 
 const aiLogger = logger.child({ subsystem: 'ai' });
@@ -1085,25 +1087,87 @@ const TOOL_DEFINITIONS: ToolDefinition[] = [
   // ── User Memory ──
   {
     name: 'save_memory',
-    description: 'Save a fact or preference about the user to remember across conversations. '
-      + 'Use when the user shares personal preferences, important facts, or asks you to remember something.',
+    description: 'Save a durable fact about the user to remember across conversations. '
+      + 'Proactively capture, as the conversation unfolds: projects the user is working on, '
+      + 'things they own, things they want or are thinking about buying, and their preferences. '
+      + 'Also use it whenever the user shares an important personal fact or asks you to remember '
+      + 'something. Avoid saving duplicates of things you already remember.',
     parameters: {
       type: 'object',
       properties: {
         content: { type: 'string', description: 'The fact or preference to remember' },
+        category: {
+          type: 'string',
+          description: 'How to classify the memory: "project" (something they are working on), '
+            + '"possession" (something they own), "wishlist" (something they want or may buy), '
+            + '"preference" (a durable preference), or "fact" (any other lasting fact). '
+            + 'Defaults to "fact".',
+          enum: ['project', 'possession', 'wishlist', 'preference', 'fact'],
+        },
       },
       required: ['content'],
     },
   },
   {
     name: 'delete_memory',
-    description: 'Delete a previously saved memory by its ID. Use when the user asks you to forget something.',
+    description: 'Delete a previously saved memory by its ID. Use when the user asks you to forget '
+      + 'one specific thing. Look up the ID with list_memories first if you do not have it.',
     parameters: {
       type: 'object',
       properties: {
         memory_id: { type: 'string', description: 'The ID of the memory to delete' },
       },
       required: ['memory_id'],
+    },
+  },
+  {
+    name: 'list_memories',
+    description: 'List everything you currently remember about the user, including each memory\'s '
+      + 'id and category. Use when the user asks what you remember or wants to review their '
+      + 'memories, and to find the right id before updating or deleting one. Optionally filter to a '
+      + 'single category.',
+    parameters: {
+      type: 'object',
+      properties: {
+        category: {
+          type: 'string',
+          description: 'Optional: only return memories in this category.',
+          enum: ['project', 'possession', 'wishlist', 'preference', 'fact'],
+        },
+      },
+    },
+  },
+  {
+    name: 'update_memory',
+    description: 'Change an existing memory by id: rewrite its text and/or move it to a different '
+      + 'category. Use when a remembered fact changes — e.g. a project is finished, they sold '
+      + 'something they owned, or a wishlist item was purchased (move it to "possession"). Provide '
+      + 'content and/or category; look up the id with list_memories first if you do not have it.',
+    parameters: {
+      type: 'object',
+      properties: {
+        memory_id: { type: 'string', description: 'The id of the memory to change' },
+        content: {
+          type: 'string',
+          description: 'New text for the memory. Omit to keep the current text.',
+        },
+        category: {
+          type: 'string',
+          description: 'New category for the memory. Omit to keep the current category.',
+          enum: ['project', 'possession', 'wishlist', 'preference', 'fact'],
+        },
+      },
+      required: ['memory_id'],
+    },
+  },
+  {
+    name: 'delete_all_memories',
+    description: 'Delete ALL of the user\'s memories at once (a full cleanup). This is destructive '
+      + 'and cannot be undone — only use it after the user explicitly confirms they want to erase '
+      + 'everything you remember about them.',
+    parameters: {
+      type: 'object',
+      properties: {},
     },
   },
 ];
@@ -1798,12 +1862,33 @@ async function executeToolInner(
   // ── User Memory ──
   case 'save_memory':
     if (!userSub) return 'Memory not available — user not authenticated';
-    return JSON.stringify(await saveMemory(userSub, args.content), null, 2);
+    return JSON.stringify(await saveMemory(userSub, args.content, args.category), null, 2);
   case 'delete_memory':
     if (!userSub) return 'Memory not available — user not authenticated';
     return (await deleteMemory(userSub, args.memory_id))
       ? 'Memory deleted successfully'
       : 'Memory not found';
+  case 'list_memories': {
+    if (!userSub) return 'Memory not available — user not authenticated';
+    const all = await listMemories(userSub);
+    const memories = args.category
+      ? all.filter((m) => m.category === normalizeCategory(args.category))
+      : all;
+    return JSON.stringify(memories, null, 2);
+  }
+  case 'update_memory': {
+    if (!userSub) return 'Memory not available — user not authenticated';
+    const updated = await updateMemory(userSub, args.memory_id, {
+      content: args.content,
+      category: args.category,
+    });
+    return updated ? JSON.stringify(updated, null, 2) : 'Memory not found';
+  }
+  case 'delete_all_memories': {
+    if (!userSub) return 'Memory not available — user not authenticated';
+    const count = await deleteAllMemories(userSub);
+    return `Deleted ${count} ${count === 1 ? 'memory' : 'memories'}`;
+  }
 
   default:
     return `Unknown tool: ${name}`;

--- a/src/ai-command.ts
+++ b/src/ai-command.ts
@@ -4,7 +4,7 @@ import { Readability } from '@mozilla/readability';
 import { parseHTML } from 'linkedom';
 import { FluxHausServices } from './services';
 import {
-  deleteAllMemories, deleteMemory, listMemories, normalizeCategory, saveMemory, updateMemory,
+  deleteAllMemories, deleteMemory, listMemories, saveMemory, updateMemory,
 } from './memory';
 import logger from './logger';
 
@@ -1878,10 +1878,7 @@ async function executeToolInner(
       : 'Memory not found';
   case 'list_memories': {
     if (!userSub) return 'Memory not available — user not authenticated';
-    const all = await listMemories(userSub);
-    const memories = args.category
-      ? all.filter((m) => m.category === normalizeCategory(args.category))
-      : all;
+    const memories = await listMemories(userSub, args.category);
     return JSON.stringify(memories, null, 2);
   }
   case 'update_memory': {

--- a/src/ai-command.ts
+++ b/src/ai-command.ts
@@ -1868,25 +1868,37 @@ async function executeToolInner(
     return 'Image generation is only available through the AI command interface.';
 
   // ── User Memory ──
-  case 'save_memory':
+  case 'save_memory': {
     if (!userSub) return 'Memory not available — user not authenticated';
-    return JSON.stringify(await saveMemory(userSub, args.content, args.category), null, 2);
+    if (typeof args.content !== 'string' || args.content.trim() === '') {
+      return 'Invalid memory: content must be a non-empty string';
+    }
+    const category = typeof args.category === 'string' ? args.category : undefined;
+    return JSON.stringify(await saveMemory(userSub, args.content, category), null, 2);
+  }
   case 'delete_memory':
     if (!userSub) return 'Memory not available — user not authenticated';
+    if (typeof args.memory_id !== 'string' || args.memory_id === '') {
+      return 'Invalid request: memory_id must be a string';
+    }
     return (await deleteMemory(userSub, args.memory_id))
       ? 'Memory deleted successfully'
       : 'Memory not found';
   case 'list_memories': {
     if (!userSub) return 'Memory not available — user not authenticated';
-    const memories = await listMemories(userSub, args.category);
+    const category = typeof args.category === 'string' ? args.category : undefined;
+    const memories = await listMemories(userSub, category);
     return JSON.stringify(memories, null, 2);
   }
   case 'update_memory': {
     if (!userSub) return 'Memory not available — user not authenticated';
-    const updated = await updateMemory(userSub, args.memory_id, {
-      content: args.content,
-      category: args.category,
-    });
+    if (typeof args.memory_id !== 'string' || args.memory_id === '') {
+      return 'Invalid update: memory_id must be a string';
+    }
+    const updates: { content?: string; category?: string } = {};
+    if (typeof args.content === 'string') updates.content = args.content;
+    if (typeof args.category === 'string') updates.category = args.category;
+    const updated = await updateMemory(userSub, args.memory_id, updates);
     return updated ? JSON.stringify(updated, null, 2) : 'Memory not found';
   }
   case 'delete_all_memories': {

--- a/src/db.ts
+++ b/src/db.ts
@@ -182,8 +182,11 @@ export async function initDatabase(): Promise<void> {
       );
       ALTER TABLE user_memories
         ADD COLUMN IF NOT EXISTS category TEXT NOT NULL DEFAULT 'fact';
-      CREATE INDEX IF NOT EXISTS idx_user_memories_user
-        ON user_memories (user_sub);
+      DROP INDEX IF EXISTS idx_user_memories_user;
+      CREATE INDEX IF NOT EXISTS idx_user_memories_user_created
+        ON user_memories (user_sub, created_at);
+      CREATE INDEX IF NOT EXISTS idx_user_memories_user_category_created
+        ON user_memories (user_sub, category, created_at);
 
       CREATE TABLE IF NOT EXISTS la_subscriptions (
         user_sub TEXT PRIMARY KEY,

--- a/src/db.ts
+++ b/src/db.ts
@@ -177,8 +177,11 @@ export async function initDatabase(): Promise<void> {
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
         user_sub TEXT NOT NULL,
         content TEXT NOT NULL,
+        category TEXT NOT NULL DEFAULT 'fact',
         created_at TIMESTAMPTZ DEFAULT NOW()
       );
+      ALTER TABLE user_memories
+        ADD COLUMN IF NOT EXISTS category TEXT NOT NULL DEFAULT 'fact';
       CREATE INDEX IF NOT EXISTS idx_user_memories_user
         ON user_memories (user_sub);
 

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -4,25 +4,81 @@ import logger from './logger';
 
 const memLogger = logger.child({ subsystem: 'memory' });
 
+/**
+ * Categories let memories be organised the way Claude's memory feature groups
+ * what it knows about a user (projects, things they own, things they want, etc.)
+ * so the assistant can recall and reason about them by topic.
+ */
+export const MEMORY_CATEGORIES = [
+  'project',
+  'possession',
+  'wishlist',
+  'preference',
+  'fact',
+] as const;
+
+export type MemoryCategory = (typeof MEMORY_CATEGORIES)[number];
+
+export const DEFAULT_MEMORY_CATEGORY: MemoryCategory = 'fact';
+
+const CATEGORY_HEADINGS: Record<MemoryCategory, string> = {
+  project: "Projects they're working on",
+  possession: 'Things they own',
+  wishlist: "Things they're thinking about buying",
+  preference: 'Preferences',
+  fact: 'Other facts',
+};
+
+export function normalizeCategory(value: string | null | undefined): MemoryCategory {
+  if (value && (MEMORY_CATEGORIES as readonly string[]).includes(value)) {
+    return value as MemoryCategory;
+  }
+  return DEFAULT_MEMORY_CATEGORY;
+}
+
 export interface Memory {
   id: string;
   content: string;
+  category: MemoryCategory;
   createdAt: string;
 }
 
-export async function saveMemory(userSub: string, content: string): Promise<Memory> {
+interface MemoryRow {
+  id: string;
+  content: string;
+  category: string;
+  created_at: string;
+}
+
+function rowToMemory(row: MemoryRow, userSub: string): Memory {
+  return {
+    id: row.id,
+    content: decrypt(row.content, userSub),
+    category: normalizeCategory(row.category),
+    createdAt: row.created_at,
+  };
+}
+
+export async function saveMemory(
+  userSub: string,
+  content: string,
+  category: string = DEFAULT_MEMORY_CATEGORY,
+): Promise<Memory> {
   const pool = getPool();
   if (!pool) throw new Error('Database not available');
 
+  const normalizedCategory = normalizeCategory(category);
   const encrypted = encrypt(content, userSub);
   const result = await pool.query(
-    'INSERT INTO user_memories (user_sub, content) VALUES ($1, $2) RETURNING id, created_at',
-    [userSub, encrypted],
+    'INSERT INTO user_memories (user_sub, content, category) VALUES ($1, $2, $3) RETURNING id, created_at',
+    [userSub, encrypted, normalizedCategory],
   );
 
   const row = result.rows[0];
-  memLogger.info({ userSub, memoryId: row.id }, 'Memory saved');
-  return { id: row.id, content, createdAt: row.created_at };
+  memLogger.info({ userSub, memoryId: row.id, category: normalizedCategory }, 'Memory saved');
+  return {
+    id: row.id, content, category: normalizedCategory, createdAt: row.created_at,
+  };
 }
 
 export async function listMemories(userSub: string): Promise<Memory[]> {
@@ -30,15 +86,57 @@ export async function listMemories(userSub: string): Promise<Memory[]> {
   if (!pool) return [];
 
   const result = await pool.query(
-    'SELECT id, content, created_at FROM user_memories WHERE user_sub = $1 ORDER BY created_at',
+    'SELECT id, content, category, created_at FROM user_memories WHERE user_sub = $1 ORDER BY created_at',
     [userSub],
   );
 
-  return result.rows.map((row) => ({
-    id: row.id,
-    content: decrypt(row.content, userSub),
-    createdAt: row.created_at,
-  }));
+  return result.rows.map((row) => rowToMemory(row, userSub));
+}
+
+/**
+ * Update an existing memory's text and/or category by id. Returns the updated
+ * memory, or null if no memory with that id belongs to the user. Passing no
+ * fields leaves the memory unchanged and returns it as-is.
+ */
+export async function updateMemory(
+  userSub: string,
+  memoryId: string,
+  updates: { content?: string; category?: string },
+): Promise<Memory | null> {
+  const pool = getPool();
+  if (!pool) throw new Error('Database not available');
+
+  const fields: string[] = [];
+  const values: unknown[] = [];
+
+  if (updates.content !== undefined) {
+    values.push(encrypt(updates.content, userSub));
+    fields.push(`content = $${values.length}`);
+  }
+  if (updates.category !== undefined) {
+    values.push(normalizeCategory(updates.category));
+    fields.push(`category = $${values.length}`);
+  }
+
+  if (fields.length === 0) {
+    const current = await pool.query(
+      'SELECT id, content, category, created_at FROM user_memories WHERE id = $1 AND user_sub = $2',
+      [memoryId, userSub],
+    );
+    return current.rowCount === 0 ? null : rowToMemory(current.rows[0], userSub);
+  }
+
+  values.push(memoryId, userSub);
+  const result = await pool.query(
+    `UPDATE user_memories SET ${fields.join(', ')}
+       WHERE id = $${values.length - 1} AND user_sub = $${values.length}
+       RETURNING id, content, category, created_at`,
+    values,
+  );
+
+  if (result.rowCount === 0) return null;
+  memLogger.info({ userSub, memoryId, category: result.rows[0].category }, 'Memory updated');
+  return rowToMemory(result.rows[0], userSub);
 }
 
 export async function deleteMemory(userSub: string, memoryId: string): Promise<boolean> {
@@ -70,18 +168,39 @@ export async function deleteAllMemories(userSub: string): Promise<number> {
 }
 
 /**
- * Build a system prompt fragment with the user's memories.
- * Returns empty string if no memories exist.
+ * Build a system prompt fragment describing the user's memories the way
+ * Claude's memory feature does: a standing instruction to proactively capture
+ * durable facts (projects, possessions, purchase ideas, preferences) without
+ * being asked, plus the current memories grouped by category. The directive is
+ * always present so the assistant captures the first memory from a blank slate;
+ * it is only reached when the user's memoryEnabled preference is on.
  */
 export async function buildMemoryPrompt(userSub: string): Promise<string> {
   const memories = await listMemories(userSub);
-  if (memories.length === 0) return '';
 
-  const memoryLines = memories.map((m) => `- [id:${m.id}] ${m.content}`).join('\n');
-  return (
-    '\n\nYou have a memory system. Here are things you remember about this user:\n'
-    + `${memoryLines}\n\n`
-    + 'Use the save_memory tool to remember new important facts, preferences, or context about the user. '
-    + 'Use the delete_memory tool if the user asks you to forget something or if a memory is outdated.'
-  );
+  const directive = '\n\nYou maintain a long-term memory about this user that persists across '
+    + 'conversations. As you talk, proactively use the save_memory tool to remember durable facts '
+    + 'on your own, without being asked — especially projects they are working on (category '
+    + '"project"), things they own ("possession"), things they want or are thinking about buying '
+    + '("wishlist"), and their preferences ("preference"); use "fact" for anything else. Do not '
+    + 'save duplicates or trivial, ephemeral details. Use the delete_memory tool when a fact '
+    + 'changes or the user asks you to forget it.';
+
+  if (memories.length === 0) {
+    return `${directive} You have no saved memories about this user yet.`;
+  }
+
+  const sections = MEMORY_CATEGORIES
+    .map((category) => ({
+      category,
+      items: memories.filter((m) => m.category === category),
+    }))
+    .filter(({ items }) => items.length > 0)
+    .map(({ category, items }) => {
+      const lines = items.map((m) => `- [id:${m.id}] ${m.content}`).join('\n');
+      return `${CATEGORY_HEADINGS[category]}:\n${lines}`;
+    })
+    .join('\n\n');
+
+  return `${directive}\n\nHere is what you currently remember, organized by category:\n\n${sections}`;
 }

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -88,14 +88,16 @@ export async function saveMemory(
   };
 }
 
-export async function listMemories(userSub: string): Promise<Memory[]> {
+export async function listMemories(userSub: string, category?: string): Promise<Memory[]> {
   const pool = getPool();
   if (!pool) return [];
 
-  const result = await pool.query(
-    'SELECT id, content, category, created_at FROM user_memories WHERE user_sub = $1 ORDER BY created_at',
-    [userSub],
-  );
+  const filterByCategory = category !== undefined;
+  const sql = `SELECT id, content, category, created_at FROM user_memories WHERE user_sub = $1${
+    filterByCategory ? ' AND category = $2' : ''} ORDER BY created_at`;
+  const params = filterByCategory ? [userSub, normalizeCategory(category)] : [userSub];
+
+  const result = await pool.query(sql, params);
 
   return result.rows.map((row) => rowToMemory(row, userSub));
 }
@@ -180,9 +182,13 @@ export async function deleteAllMemories(userSub: string): Promise<number> {
  * durable facts (projects, possessions, purchase ideas, preferences) without
  * being asked, plus the current memories grouped by category. The directive is
  * always present so the assistant captures the first memory from a blank slate;
- * it is only reached when the user's memoryEnabled preference is on.
+ * it is only reached when the user's memoryEnabled preference is on. When the
+ * database is unavailable the directive is omitted entirely, so the assistant is
+ * not told to call memory tools that would fail during an outage or startup.
  */
 export async function buildMemoryPrompt(userSub: string): Promise<string> {
+  if (!getPool()) return '';
+
   const memories = await listMemories(userSub);
 
   const directive = '\n\nYou maintain a long-term memory about this user that persists across '

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -183,8 +183,9 @@ export async function buildMemoryPrompt(userSub: string): Promise<string> {
     + 'on your own, without being asked — especially projects they are working on (category '
     + '"project"), things they own ("possession"), things they want or are thinking about buying '
     + '("wishlist"), and their preferences ("preference"); use "fact" for anything else. Do not '
-    + 'save duplicates or trivial, ephemeral details. Use the delete_memory tool when a fact '
-    + 'changes or the user asks you to forget it.';
+    + 'save duplicates or trivial, ephemeral details. Use the update_memory tool when a remembered '
+    + 'fact changes (for example, move a wishlist item to "possession" once they buy it), and the '
+    + 'delete_memory tool when the user asks you to forget something.';
 
   if (memories.length === 0) {
     return `${directive} You have no saved memories about this user yet.`;

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -92,9 +92,9 @@ export async function listMemories(userSub: string, category?: string): Promise<
   const pool = getPool();
   if (!pool) return [];
 
-  const filterByCategory = category !== undefined;
+  const filterByCategory = typeof category === 'string' && category !== '';
   const sql = `SELECT id, content, category, created_at FROM user_memories WHERE user_sub = $1${
-    filterByCategory ? ' AND category = $2' : ''} ORDER BY created_at`;
+    filterByCategory ? ' AND category = $2' : ''} ORDER BY created_at, id`;
   const params = filterByCategory ? [userSub, normalizeCategory(category)] : [userSub];
 
   const result = await pool.query(sql, params);

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -21,6 +21,13 @@ export type MemoryCategory = (typeof MEMORY_CATEGORIES)[number];
 
 export const DEFAULT_MEMORY_CATEGORY: MemoryCategory = 'fact';
 
+/**
+ * Upper bound on how many memories are embedded verbatim in the system prompt.
+ * The most recent memories are kept; the rest stay retrievable via list_memories.
+ * This bounds prompt size (and cost) as a user's memory set grows.
+ */
+export const MAX_MEMORIES_IN_PROMPT = 200;
+
 const CATEGORY_HEADINGS: Record<MemoryCategory, string> = {
   project: "Projects they're working on",
   possession: 'Things they own',
@@ -46,7 +53,7 @@ export interface Memory {
 interface MemoryRow {
   id: string;
   content: string;
-  category: string;
+  category?: string | null;
   created_at: string;
 }
 
@@ -191,10 +198,15 @@ export async function buildMemoryPrompt(userSub: string): Promise<string> {
     return `${directive} You have no saved memories about this user yet.`;
   }
 
+  // Bound the prompt: embed only the most recently created memories verbatim.
+  const included = memories.length > MAX_MEMORIES_IN_PROMPT
+    ? memories.slice(memories.length - MAX_MEMORIES_IN_PROMPT)
+    : memories;
+
   const sections = MEMORY_CATEGORIES
     .map((category) => ({
       category,
-      items: memories.filter((m) => m.category === category),
+      items: included.filter((m) => m.category === category),
     }))
     .filter(({ items }) => items.length > 0)
     .map(({ category, items }) => {
@@ -203,5 +215,11 @@ export async function buildMemoryPrompt(userSub: string): Promise<string> {
     })
     .join('\n\n');
 
-  return `${directive}\n\nHere is what you currently remember, organized by category:\n\n${sections}`;
+  const truncationNote = included.length < memories.length
+    ? `\n\n(Showing the ${included.length} most recent of ${memories.length} memories; `
+      + 'use list_memories to review them all.)'
+    : '';
+
+  return `${directive}\n\nHere is what you currently remember, organized by category:\n\n`
+    + `${sections}${truncationNote}`;
 }


### PR DESCRIPTION
## Summary

Reworks the assistant's long-term memory to mirror how Claude's memory feature works — organized by **category** and captured **proactively as you chat** — and adds full conversational management of memories.

### Categorization
- New categories: `project`, `possession`, `wishlist`, `preference`, `fact` (default), with a `category` column + `ALTER TABLE` migration. Content stays encrypted at rest; the category is a plaintext classifier.
- `buildMemoryPrompt` now presents remembered facts grouped under friendly headings (e.g. "Projects they're working on", "Things they own", "Things they're thinking about buying").

### Proactive capture
- Always-on standing directive (gated by the user's `memoryEnabled` preference) tells the assistant to save durable facts on its own — projects, possessions, purchase ideas, preferences — without being asked.
- `save_memory` gained a `category` parameter and a proactive-capture description.

### Conversational management (new tools)
| Action | Tool |
|--------|------|
| List | `list_memories` (optional category filter) |
| Add | `save_memory` |
| Change | `update_memory` (text and/or category by id) |
| Remove | `delete_memory` |
| Cleanup | `delete_all_memories` (confirmation-gated, destructive) |

### Tests & docs
- Added/updated unit tests for categories, `updateMemory`, and the grouped prompt; updated two `/voice` server tests for the always-on directive.
- Documented the `user_memories` table, categories, and management tools in the README.

All local checks pass: ESLint, `tsc --noEmit`, 486/486 Jest tests, and the production webpack build.