### PR TITLE
feat: add Blue Pure air purifier control

### DIFF
--- a/src/__tests__/blueair.test.ts
+++ b/src/__tests__/blueair.test.ts
@@ -3,11 +3,6 @@ import { HomeAssistantClient } from '../homeassistant-client';
 
 jest.mock('../homeassistant-client');
 
-jest.mock('../influx', () => ({
-  __esModule: true,
-  writePoint: jest.fn(),
-}));
-
 jest.mock('../logger', () => ({
   __esModule: true,
   default: {

--- a/src/__tests__/blueair.test.ts
+++ b/src/__tests__/blueair.test.ts
@@ -1,0 +1,134 @@
+import Blueair from '../blueair';
+import { HomeAssistantClient } from '../homeassistant-client';
+
+jest.mock('../homeassistant-client');
+
+jest.mock('../influx', () => ({
+  __esModule: true,
+  writePoint: jest.fn(),
+}));
+
+jest.mock('../logger', () => ({
+  __esModule: true,
+  default: {
+    child: () => ({
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    }),
+  },
+}));
+
+describe('Blueair', () => {
+  let mockClient: jest.Mocked<HomeAssistantClient>;
+  let blueair: Blueair;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockClient = new HomeAssistantClient({ url: 'http://test', token: 'token' }) as jest.Mocked<HomeAssistantClient>;
+    mockClient.getState = jest.fn().mockResolvedValue({ state: 'off', attributes: {} });
+    mockClient.callService = jest.fn().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    if (blueair) {
+      blueair.stop();
+    }
+  });
+
+  it('initializes with an empty cached status', () => {
+    blueair = new Blueair({ client: mockClient });
+    expect(blueair.cachedStatus.online).toBe(false);
+    expect(blueair.cachedStatus.fanOn).toBe(false);
+  });
+
+  it('maps Home Assistant state into cached status', async () => {
+    mockClient.getState = jest.fn().mockImplementation((entityId: string) => {
+      if (entityId === 'fan.blue_pure_fan') {
+        return Promise.resolve({
+          state: 'on',
+          attributes: { percentage: 50, preset_mode: 'auto', preset_modes: ['auto', 'night'] },
+        });
+      }
+      if (entityId === 'light.blue_pure_led_light') {
+        return Promise.resolve({ state: 'on', attributes: { brightness: 128 } });
+      }
+      if (entityId === 'sensor.blue_pure_pm_2_5') {
+        return Promise.resolve({ state: '7' });
+      }
+      if (entityId === 'sensor.blue_pure_filter_life') {
+        return Promise.resolve({ state: '80' });
+      }
+      if (entityId === 'binary_sensor.blue_pure_online') {
+        return Promise.resolve({ state: 'on' });
+      }
+      return Promise.resolve({ state: 'off', attributes: {} });
+    });
+
+    blueair = new Blueair({ client: mockClient });
+    await new Promise<void>((resolve) => { setTimeout(resolve, 0); });
+
+    expect(blueair.cachedStatus.online).toBe(true);
+    expect(blueair.cachedStatus.fanOn).toBe(true);
+    expect(blueair.cachedStatus.fanSpeed).toBe(50);
+    expect(blueair.cachedStatus.presetMode).toBe('auto');
+    expect(blueair.cachedStatus.lightOn).toBe(true);
+    expect(blueair.cachedStatus.pm25).toBe(7);
+    expect(blueair.cachedStatus.filterLife).toBe(80);
+  });
+
+  it('turns the fan on and off', async () => {
+    blueair = new Blueair({ client: mockClient });
+    await blueair.setFan(true);
+    expect(mockClient.callService).toHaveBeenCalledWith('fan', 'turn_on', { entity_id: 'fan.blue_pure_fan' });
+    await blueair.setFan(false);
+    expect(mockClient.callService).toHaveBeenCalledWith('fan', 'turn_off', { entity_id: 'fan.blue_pure_fan' });
+  });
+
+  it('clamps fan speed to the 0-100 range', async () => {
+    blueair = new Blueair({ client: mockClient });
+    await blueair.setSpeed(150);
+    expect(mockClient.callService).toHaveBeenCalledWith('fan', 'set_percentage', {
+      entity_id: 'fan.blue_pure_fan',
+      percentage: 100,
+    });
+  });
+
+  it('rejects an invalid preset mode', async () => {
+    blueair = new Blueair({ client: mockClient });
+    await expect(blueair.setPreset('bogus')).rejects.toThrow('Invalid preset mode');
+    expect(mockClient.callService).not.toHaveBeenCalledWith('fan', 'set_preset_mode', expect.anything());
+  });
+
+  it('accepts a valid preset mode', async () => {
+    blueair = new Blueair({ client: mockClient });
+    const result = await blueair.setPreset('auto');
+    expect(mockClient.callService).toHaveBeenCalledWith('fan', 'set_preset_mode', {
+      entity_id: 'fan.blue_pure_fan',
+      preset_mode: 'auto',
+    });
+    expect(result).toBe('Preset auto');
+  });
+
+  it('controls the LED light and brightness', async () => {
+    blueair = new Blueair({ client: mockClient });
+    await blueair.setLight(true);
+    expect(mockClient.callService).toHaveBeenCalledWith('light', 'turn_on', { entity_id: 'light.blue_pure_led_light' });
+    await blueair.setBrightness(200);
+    expect(mockClient.callService).toHaveBeenCalledWith('light', 'turn_on', {
+      entity_id: 'light.blue_pure_led_light',
+      brightness_pct: 100,
+    });
+  });
+
+  it('stops polling when stopped', () => {
+    jest.useFakeTimers();
+    const clearSpy = jest.spyOn(global, 'clearInterval');
+    blueair = new Blueair({ client: mockClient });
+    blueair.stop();
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
+    jest.useRealTimers();
+  });
+});

--- a/src/__tests__/blueair.test.ts
+++ b/src/__tests__/blueair.test.ts
@@ -78,6 +78,18 @@ describe('Blueair', () => {
     expect(blueair.cachedStatus.filterLife).toBe(80);
   });
 
+  it('normalizes light brightness to a percentage', async () => {
+    mockClient.getState = jest.fn().mockImplementation((entityId: string) => {
+      if (entityId === 'light.blue_pure_led_light') {
+        return Promise.resolve({ state: 'on', attributes: { brightness: 255 } });
+      }
+      return Promise.resolve({ state: 'off', attributes: {} });
+    });
+    blueair = new Blueair({ client: mockClient });
+    await new Promise<void>((resolve) => { setTimeout(resolve, 0); });
+    expect(blueair.cachedStatus.brightness).toBe(100);
+  });
+
   it('turns the fan on and off', async () => {
     blueair = new Blueair({ client: mockClient });
     await blueair.setFan(true);

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -295,6 +295,14 @@ describe('Server', () => {
       .expect(400);
   });
 
+  it('should reject an unsupported air purifier preset mode', async () => {
+    await request(app)
+      .post('/airPurifierPreset')
+      .set('Authorization', oidcAuthHeader)
+      .send({ mode: 'bogus' })
+      .expect(400);
+  });
+
   it('should control the air purifier light for admin', async () => {
     await request(app)
       .post('/airPurifierLight')

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -255,6 +255,54 @@ describe('Server', () => {
     expect(mockMopbot.turnOff).toHaveBeenCalled();
   });
 
+  it('should control the air purifier fan for admin', async () => {
+    await request(app)
+      .post('/airPurifierFan')
+      .set('Authorization', oidcAuthHeader)
+      .send({ on: true })
+      .expect(200);
+  });
+
+  it('should reject air purifier fan control for non-admin', async () => {
+    await request(app)
+      .post('/airPurifierFan')
+      .set('Authorization', basicAuthHeader('demo', 'demopassword'))
+      .send({ on: true })
+      .expect(403);
+  });
+
+  it('should validate air purifier speed input', async () => {
+    await request(app)
+      .post('/airPurifierSpeed')
+      .set('Authorization', oidcAuthHeader)
+      .send({})
+      .expect(400);
+  });
+
+  it('should set the air purifier speed for admin', async () => {
+    await request(app)
+      .post('/airPurifierSpeed')
+      .set('Authorization', oidcAuthHeader)
+      .send({ percentage: 50 })
+      .expect(200);
+  });
+
+  it('should validate the air purifier preset mode', async () => {
+    await request(app)
+      .post('/airPurifierPreset')
+      .set('Authorization', oidcAuthHeader)
+      .send({ mode: 'bad mode!' })
+      .expect(400);
+  });
+
+  it('should control the air purifier light for admin', async () => {
+    await request(app)
+      .post('/airPurifierLight')
+      .set('Authorization', oidcAuthHeader)
+      .send({ on: true })
+      .expect(200);
+  });
+
   it('should handle deep clean', async () => {
     jest.useFakeTimers({ doNotFake: ['setImmediate', 'nextTick'] });
     await request(app)

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -287,6 +287,14 @@ describe('Server', () => {
       .expect(200);
   });
 
+  it('should reject air purifier fan control without an on flag', async () => {
+    await request(app)
+      .post('/airPurifierFan')
+      .set('Authorization', oidcAuthHeader)
+      .send({})
+      .expect(400);
+  });
+
   it('should validate the air purifier preset mode', async () => {
     await request(app)
       .post('/airPurifierPreset')

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -311,6 +311,14 @@ describe('Server', () => {
       .expect(400);
   });
 
+  it('should reject air purifier light control without brightness or on flag', async () => {
+    await request(app)
+      .post('/airPurifierLight')
+      .set('Authorization', oidcAuthHeader)
+      .send({ brightness: null })
+      .expect(400);
+  });
+
   it('should control the air purifier light for admin', async () => {
     await request(app)
       .post('/airPurifierLight')

--- a/src/blueair.ts
+++ b/src/blueair.ts
@@ -1,5 +1,4 @@
 import { HomeAssistantClient } from './homeassistant-client';
-import { writePoint } from './influx';
 import logger from './logger';
 
 const blueairLogger = logger.child({ subsystem: 'blueair' });
@@ -24,7 +23,6 @@ export interface BlueairConfig {
   pm25EntityId?: string;
   filterEntityId?: string;
   onlineEntityId?: string;
-  device?: string;
   pollInterval?: number;
 }
 
@@ -79,8 +77,6 @@ export default class Blueair {
 
   private onlineEntityId: string;
 
-  private device: string;
-
   private timer: ReturnType<typeof setInterval> | null = null;
 
   constructor(config: BlueairConfig) {
@@ -90,7 +86,6 @@ export default class Blueair {
     this.pm25EntityId = config.pm25EntityId || 'sensor.blue_pure_pm_2_5';
     this.filterEntityId = config.filterEntityId || 'sensor.blue_pure_filter_life';
     this.onlineEntityId = config.onlineEntityId || 'binary_sensor.blue_pure_online';
-    this.device = config.device || 'blue_pure';
     this.startPolling(config.pollInterval ?? 1000 * 60);
   }
 
@@ -134,13 +129,6 @@ export default class Blueair {
         pm25: pm25Value,
         filterLife: filterValue,
       };
-
-      if (pm25Value !== null || filterValue !== null) {
-        const fields: Record<string, number> = {};
-        if (pm25Value !== null) fields.pm25 = pm25Value;
-        if (filterValue !== null) fields.filter_life = filterValue;
-        writePoint('air_purifier', fields, { device: this.device });
-      }
 
       this.onStatusChange?.(this.cachedStatus);
     } catch (err) {

--- a/src/blueair.ts
+++ b/src/blueair.ts
@@ -1,0 +1,169 @@
+import { HomeAssistantClient } from './homeassistant-client';
+import { writePoint } from './influx';
+import logger from './logger';
+
+const blueairLogger = logger.child({ subsystem: 'blueair' });
+
+export interface BlueairStatus {
+  timestamp: Date;
+  online: boolean;
+  fanOn: boolean;
+  fanSpeed: number | null;
+  presetMode: string | null;
+  presetModes: string[];
+  lightOn: boolean;
+  brightness: number | null;
+  pm25: number | null;
+  filterLife: number | null;
+}
+
+export interface BlueairConfig {
+  client: HomeAssistantClient;
+  fanEntityId?: string;
+  lightEntityId?: string;
+  pm25EntityId?: string;
+  filterEntityId?: string;
+  onlineEntityId?: string;
+  device?: string;
+  pollInterval?: number;
+}
+
+const EMPTY_STATUS: BlueairStatus = {
+  timestamp: new Date(0),
+  online: false,
+  fanOn: false,
+  fanSpeed: null,
+  presetMode: null,
+  presetModes: [],
+  lightOn: false,
+  brightness: null,
+  pm25: null,
+  filterLife: null,
+};
+
+function toNumber(value: unknown): number | null {
+  const parsed = typeof value === 'number' ? value : parseFloat(String(value));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export default class Blueair {
+  public cachedStatus: BlueairStatus = EMPTY_STATUS;
+
+  public onStatusChange?: (status: BlueairStatus) => void;
+
+  private client: HomeAssistantClient;
+
+  private fanEntityId: string;
+
+  private lightEntityId: string;
+
+  private pm25EntityId: string;
+
+  private filterEntityId: string;
+
+  private onlineEntityId: string;
+
+  private device: string;
+
+  constructor(config: BlueairConfig) {
+    this.client = config.client;
+    this.fanEntityId = config.fanEntityId || 'fan.blue_pure_fan';
+    this.lightEntityId = config.lightEntityId || 'light.blue_pure_led_light';
+    this.pm25EntityId = config.pm25EntityId || 'sensor.blue_pure_pm_2_5';
+    this.filterEntityId = config.filterEntityId || 'sensor.blue_pure_filter_life';
+    this.onlineEntityId = config.onlineEntityId || 'binary_sensor.blue_pure_online';
+    this.device = config.device || 'blue_pure';
+    this.startPolling(config.pollInterval ?? 1000 * 60);
+  }
+
+  private startPolling(interval: number) {
+    this.updateStatus().catch(() => {});
+    setInterval(() => {
+      this.updateStatus().catch(() => {});
+    }, interval);
+  }
+
+  private async updateStatus() {
+    try {
+      const [fan, light, pm25, filter, online] = await Promise.all([
+        this.client.getState(this.fanEntityId).catch(() => null),
+        this.client.getState(this.lightEntityId).catch(() => null),
+        this.client.getState(this.pm25EntityId).catch(() => null),
+        this.client.getState(this.filterEntityId).catch(() => null),
+        this.client.getState(this.onlineEntityId).catch(() => null),
+      ]);
+
+      const pm25Value = pm25 ? toNumber(pm25.state) : null;
+      const filterValue = filter ? toNumber(filter.state) : null;
+
+      this.cachedStatus = {
+        timestamp: new Date(),
+        online: online ? online.state === 'on' : false,
+        fanOn: fan ? fan.state === 'on' : false,
+        fanSpeed: fan ? toNumber(fan.attributes?.percentage) : null,
+        presetMode: fan?.attributes?.preset_mode ?? null,
+        presetModes: fan?.attributes?.preset_modes ?? [],
+        lightOn: light ? light.state === 'on' : false,
+        brightness: light ? toNumber(light.attributes?.brightness) : null,
+        pm25: pm25Value,
+        filterLife: filterValue,
+      };
+
+      if (pm25Value !== null || filterValue !== null) {
+        const fields: Record<string, number> = {};
+        if (pm25Value !== null) fields.pm25 = pm25Value;
+        if (filterValue !== null) fields.filter_life = filterValue;
+        writePoint('air_purifier', fields, { device: this.device });
+      }
+
+      this.onStatusChange?.(this.cachedStatus);
+    } catch (err) {
+      blueairLogger.error({ err }, 'Failed to update Blueair status');
+    }
+  }
+
+  public async setFan(on: boolean): Promise<string> {
+    await this.client.callService('fan', on ? 'turn_on' : 'turn_off', {
+      entity_id: this.fanEntityId,
+    });
+    await this.updateStatus();
+    return on ? 'Fan on' : 'Fan off';
+  }
+
+  public async setSpeed(percentage: number): Promise<string> {
+    const clamped = Math.max(0, Math.min(100, Math.round(percentage)));
+    await this.client.callService('fan', 'set_percentage', {
+      entity_id: this.fanEntityId,
+      percentage: clamped,
+    });
+    await this.updateStatus();
+    return `Fan speed ${clamped}%`;
+  }
+
+  public async setPreset(mode: string): Promise<string> {
+    await this.client.callService('fan', 'set_preset_mode', {
+      entity_id: this.fanEntityId,
+      preset_mode: mode,
+    });
+    await this.updateStatus();
+    return `Preset ${mode}`;
+  }
+
+  public async setLight(on: boolean): Promise<string> {
+    await this.client.callService('light', on ? 'turn_on' : 'turn_off', {
+      entity_id: this.lightEntityId,
+    });
+    await this.updateStatus();
+    return on ? 'Light on' : 'Light off';
+  }
+
+  public async setBrightness(percentage: number): Promise<string> {
+    const clamped = Math.max(0, Math.min(100, Math.round(percentage)));
+    await this.client.callService('light', 'turn_on', {
+      entity_id: this.lightEntityId,
+      brightness_pct: clamped,
+    });
+    await this.updateStatus();
+    return `Brightness ${clamped}%`;
+  }
+}

--- a/src/blueair.ts
+++ b/src/blueair.ts
@@ -65,6 +65,8 @@ export default class Blueair {
 
   private device: string;
 
+  private timer: ReturnType<typeof setInterval> | null = null;
+
   constructor(config: BlueairConfig) {
     this.client = config.client;
     this.fanEntityId = config.fanEntityId || 'fan.blue_pure_fan';
@@ -78,9 +80,17 @@ export default class Blueair {
 
   private startPolling(interval: number) {
     this.updateStatus().catch(() => {});
-    setInterval(() => {
+    this.timer = setInterval(() => {
       this.updateStatus().catch(() => {});
     }, interval);
+    this.timer.unref?.();
+  }
+
+  public stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
   }
 
   private async updateStatus() {
@@ -141,6 +151,12 @@ export default class Blueair {
   }
 
   public async setPreset(mode: string): Promise<string> {
+    const allowed = this.cachedStatus.presetModes.length > 0
+      ? this.cachedStatus.presetModes
+      : ['auto', 'night', 'manual'];
+    if (!allowed.includes(mode)) {
+      throw new Error(`Invalid preset mode: ${mode}`);
+    }
     await this.client.callService('fan', 'set_preset_mode', {
       entity_id: this.fanEntityId,
       preset_mode: mode,

--- a/src/blueair.ts
+++ b/src/blueair.ts
@@ -46,6 +46,22 @@ function toNumber(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function toStringOrNull(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function toStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
+}
+
+// Home Assistant reports light brightness on a 0-255 scale; convert it to a
+// 0-100 percentage so it matches the brightness_pct value the API accepts.
+function brightnessToPercent(value: unknown): number | null {
+  const raw = toNumber(value);
+  if (raw === null) return null;
+  return Math.round((Math.max(0, Math.min(255, raw)) / 255) * 100);
+}
+
 export default class Blueair {
   public cachedStatus: BlueairStatus = EMPTY_STATUS;
 
@@ -111,10 +127,10 @@ export default class Blueair {
         online: online ? online.state === 'on' : false,
         fanOn: fan ? fan.state === 'on' : false,
         fanSpeed: fan ? toNumber(fan.attributes?.percentage) : null,
-        presetMode: fan?.attributes?.preset_mode ?? null,
-        presetModes: fan?.attributes?.preset_modes ?? [],
+        presetMode: toStringOrNull(fan?.attributes?.preset_mode),
+        presetModes: toStringArray(fan?.attributes?.preset_modes),
         lightOn: light ? light.state === 'on' : false,
-        brightness: light ? toNumber(light.attributes?.brightness) : null,
+        brightness: light ? brightnessToPercent(light.attributes?.brightness) : null,
         pm25: pm25Value,
         filterLife: filterValue,
       };
@@ -155,7 +171,9 @@ export default class Blueair {
       ? this.cachedStatus.presetModes
       : ['auto', 'night', 'manual'];
     if (!allowed.includes(mode)) {
-      throw new Error(`Invalid preset mode: ${mode}`);
+      const error = new Error(`Invalid preset mode: ${mode}`);
+      error.name = 'InvalidPresetError';
+      throw error;
     }
     await this.client.callService('fan', 'set_preset_mode', {
       entity_id: this.fanEntityId,

--- a/src/blueair.ts
+++ b/src/blueair.ts
@@ -26,18 +26,20 @@ export interface BlueairConfig {
   pollInterval?: number;
 }
 
-const EMPTY_STATUS: BlueairStatus = {
-  timestamp: new Date(0),
-  online: false,
-  fanOn: false,
-  fanSpeed: null,
-  presetMode: null,
-  presetModes: [],
-  lightOn: false,
-  brightness: null,
-  pm25: null,
-  filterLife: null,
-};
+function emptyStatus(): BlueairStatus {
+  return {
+    timestamp: new Date(0),
+    online: false,
+    fanOn: false,
+    fanSpeed: null,
+    presetMode: null,
+    presetModes: [],
+    lightOn: false,
+    brightness: null,
+    pm25: null,
+    filterLife: null,
+  };
+}
 
 function toNumber(value: unknown): number | null {
   const parsed = typeof value === 'number' ? value : parseFloat(String(value));
@@ -61,7 +63,7 @@ function brightnessToPercent(value: unknown): number | null {
 }
 
 export default class Blueair {
-  public cachedStatus: BlueairStatus = EMPTY_STATUS;
+  public cachedStatus: BlueairStatus = emptyStatus();
 
   public onStatusChange?: (status: BlueairStatus) => void;
 

--- a/src/blueair.ts
+++ b/src/blueair.ts
@@ -157,6 +157,11 @@ export default class Blueair {
   }
 
   public async setPreset(mode: string): Promise<string> {
+    // If we have never successfully polled the device, try once so we can
+    // validate against the modes it actually reports rather than guessing.
+    if (this.cachedStatus.presetModes.length === 0) {
+      await this.updateStatus();
+    }
     const allowed = this.cachedStatus.presetModes.length > 0
       ? this.cachedStatus.presetModes
       : ['auto', 'night', 'manual'];

--- a/src/server.ts
+++ b/src/server.ts
@@ -724,7 +724,8 @@ export async function createServer(): Promise<Express> {
       res.status(403).send('Forbidden');
       return;
     }
-    const mode = String(req.body?.mode ?? '');
+    const rawMode = req.body?.mode;
+    const mode = typeof rawMode === 'string' ? rawMode : '';
     if (!/^[a-zA-Z0-9_-]+$/.test(mode)) {
       res.status(400).send('mode is required');
       return;

--- a/src/server.ts
+++ b/src/server.ts
@@ -717,6 +717,10 @@ export async function createServer(): Promise<Express> {
       const result = await blueair.setPreset(mode);
       res.send(result);
     } catch (err) {
+      if ((err as Error).name === 'InvalidPresetError') {
+        res.status(400).send('Invalid preset mode');
+        return;
+      }
       serverLogger.error({ err }, 'airPurifierPreset failed');
       res.status(502).send('Air purifier preset control failed');
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,15 +73,21 @@ import { createCalendarService } from './calendar';
 
 const serverLogger = logger.child({ subsystem: 'server' });
 
-// Parses a request "on" flag, defaulting to true unless the value is an
-// explicit falsy value (boolean false, or strings like "false"/"0"/"off"/"no").
-function parseOnFlag(value: unknown): boolean {
+// Parses a request "on" flag. Returns true/false for recognized values and
+// null for a missing or unrecognized value so callers can reject it with 400.
+function parseOnFlag(value: unknown): boolean | null {
   if (typeof value === 'boolean') return value;
-  if (typeof value === 'number') return value !== 0;
-  if (typeof value === 'string') {
-    return !['false', '0', 'off', 'no'].includes(value.trim().toLowerCase());
+  if (typeof value === 'number') {
+    if (value === 1) return true;
+    if (value === 0) return false;
+    return null;
   }
-  return value !== false;
+  if (typeof value === 'string') {
+    const v = value.trim().toLowerCase();
+    if (['true', '1', 'on', 'yes'].includes(v)) return true;
+    if (['false', '0', 'off', 'no'].includes(v)) return false;
+  }
+  return null;
 }
 
 const port = process.env.PORT || 8888;
@@ -675,8 +681,13 @@ export async function createServer(): Promise<Express> {
       res.status(403).send('Forbidden');
       return;
     }
+    const on = parseOnFlag(req.body?.on);
+    if (on === null) {
+      res.status(400).send('on flag is required');
+      return;
+    }
     try {
-      const result = await blueair.setFan(parseOnFlag(req.body?.on));
+      const result = await blueair.setFan(on);
       res.send(result);
     } catch (err) {
       serverLogger.error({ err }, 'airPurifierFan failed');
@@ -689,9 +700,14 @@ export async function createServer(): Promise<Express> {
       res.status(403).send('Forbidden');
       return;
     }
-    const percentage = Number(req.body?.percentage);
-    if (!Number.isFinite(percentage)) {
+    const raw = req.body?.percentage;
+    if (raw === undefined || raw === null || raw === '') {
       res.status(400).send('percentage is required');
+      return;
+    }
+    const percentage = Number(raw);
+    if (!Number.isFinite(percentage)) {
+      res.status(400).send('percentage must be a number');
       return;
     }
     try {
@@ -731,18 +747,28 @@ export async function createServer(): Promise<Express> {
       res.status(403).send('Forbidden');
       return;
     }
-    try {
-      if (req.body?.brightness !== undefined) {
-        const brightness = Number(req.body.brightness);
-        if (!Number.isFinite(brightness)) {
-          res.status(400).send('brightness must be a number');
-          return;
-        }
-        const result = await blueair.setBrightness(brightness);
-        res.send(result);
+    if (req.body?.brightness !== undefined) {
+      const brightness = Number(req.body.brightness);
+      if (!Number.isFinite(brightness)) {
+        res.status(400).send('brightness must be a number');
         return;
       }
-      const result = await blueair.setLight(parseOnFlag(req.body?.on));
+      try {
+        const result = await blueair.setBrightness(brightness);
+        res.send(result);
+      } catch (err) {
+        serverLogger.error({ err }, 'airPurifierLight failed');
+        res.status(502).send('Air purifier light control failed');
+      }
+      return;
+    }
+    const on = parseOnFlag(req.body?.on);
+    if (on === null) {
+      res.status(400).send('on flag or brightness is required');
+      return;
+    }
+    try {
+      const result = await blueair.setLight(on);
       res.send(result);
     } catch (err) {
       serverLogger.error({ err }, 'airPurifierLight failed');

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,6 +73,17 @@ import { createCalendarService } from './calendar';
 
 const serverLogger = logger.child({ subsystem: 'server' });
 
+// Parses a request "on" flag, defaulting to true unless the value is an
+// explicit falsy value (boolean false, or strings like "false"/"0"/"off"/"no").
+function parseOnFlag(value: unknown): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value !== 0;
+  if (typeof value === 'string') {
+    return !['false', '0', 'off', 'no'].includes(value.trim().toLowerCase());
+  }
+  return value !== false;
+}
+
 const port = process.env.PORT || 8888;
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -283,11 +294,11 @@ export async function createServer(): Promise<Express> {
 
   const blueair = new Blueair({
     client: homeAssistantClient,
-    fanEntityId: (process.env.BLUEAIR_FAN_ENTITY_ID || 'fan.blue_pure_fan').trim(),
-    lightEntityId: (process.env.BLUEAIR_LIGHT_ENTITY_ID || 'light.blue_pure_led_light').trim(),
-    pm25EntityId: (process.env.BLUEAIR_PM25_ENTITY_ID || 'sensor.blue_pure_pm_2_5').trim(),
-    filterEntityId: (process.env.BLUEAIR_FILTER_ENTITY_ID || 'sensor.blue_pure_filter_life').trim(),
-    onlineEntityId: (process.env.BLUEAIR_ONLINE_ENTITY_ID || 'binary_sensor.blue_pure_online').trim(),
+    fanEntityId: process.env.BLUEAIR_FAN_ENTITY_ID?.trim() || 'fan.blue_pure_fan',
+    lightEntityId: process.env.BLUEAIR_LIGHT_ENTITY_ID?.trim() || 'light.blue_pure_led_light',
+    pm25EntityId: process.env.BLUEAIR_PM25_ENTITY_ID?.trim() || 'sensor.blue_pure_pm_2_5',
+    filterEntityId: process.env.BLUEAIR_FILTER_ENTITY_ID?.trim() || 'sensor.blue_pure_filter_life',
+    onlineEntityId: process.env.BLUEAIR_ONLINE_ENTITY_ID?.trim() || 'binary_sensor.blue_pure_online',
   });
 
   setInterval(() => {
@@ -665,7 +676,7 @@ export async function createServer(): Promise<Express> {
       return;
     }
     try {
-      const result = await blueair.setFan(req.body?.on !== false);
+      const result = await blueair.setFan(parseOnFlag(req.body?.on));
       res.send(result);
     } catch (err) {
       serverLogger.error({ err }, 'airPurifierFan failed');
@@ -727,7 +738,7 @@ export async function createServer(): Promise<Express> {
         res.send(result);
         return;
       }
-      const result = await blueair.setLight(req.body?.on !== false);
+      const result = await blueair.setLight(parseOnFlag(req.body?.on));
       res.send(result);
     } catch (err) {
       serverLogger.error({ err }, 'airPurifierLight failed');

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,6 +25,7 @@ import { HomeAssistantClient } from './homeassistant-client';
 import Car, { CarConfig, CarStartOptions } from './car';
 import HomeAssistantMiele from './homeassistant-miele';
 import HomeAssistantDishwasher from './homeassistant-dishwasher';
+import Blueair from './blueair';
 import adminRouter from './routes/admin.routes';
 import pushRouter from './routes/push.routes';
 import liveActivityTestRouter from './routes/live-activity-test.routes';
@@ -280,6 +281,15 @@ export async function createServer(): Promise<Express> {
     onDishwasherStatusChange(dw).catch(() => {});
   };
 
+  const blueair = new Blueair({
+    client: homeAssistantClient,
+    fanEntityId: (process.env.BLUEAIR_FAN_ENTITY_ID || 'fan.blue_pure_fan').trim(),
+    lightEntityId: (process.env.BLUEAIR_LIGHT_ENTITY_ID || 'light.blue_pure_led_light').trim(),
+    pm25EntityId: (process.env.BLUEAIR_PM25_ENTITY_ID || 'sensor.blue_pure_pm_2_5').trim(),
+    filterEntityId: (process.env.BLUEAIR_FILTER_ENTITY_ID || 'sensor.blue_pure_filter_life').trim(),
+    onlineEntityId: (process.env.BLUEAIR_ONLINE_ENTITY_ID || 'binary_sensor.blue_pure_online').trim(),
+  });
+
   setInterval(() => {
     fs.writeFileSync(
       'cache/dishwasher.json',
@@ -528,6 +538,7 @@ export async function createServer(): Promise<Express> {
         dishwasher: dishwasher.dishwasher,
         washer: mieleClient.washer,
         dryer: mieleClient.dryer,
+        airPurifier: blueair.cachedStatus,
       };
     } else if (role === 'rhizome') {
       data = {
@@ -586,6 +597,7 @@ export async function createServer(): Promise<Express> {
         dishwasher: dishwasher.dishwasher,
         washer: mieleClient.washer,
         dryer: mieleClient.dryer,
+        airPurifier: blueair.cachedStatus,
       };
     }
     res.end(JSON.stringify(data));
@@ -644,6 +656,83 @@ export async function createServer(): Promise<Express> {
     }
     await mopbot.turnOff();
     res.send('Broombot is turned off.');
+  });
+
+  // Blue Pure air purifier controls
+  app.post('/airPurifierFan', cors(corsOptions), csrfMiddleware, async (req, res) => {
+    if (req.user?.role !== 'admin') {
+      res.status(403).send('Forbidden');
+      return;
+    }
+    try {
+      const result = await blueair.setFan(req.body?.on !== false);
+      res.send(result);
+    } catch (err) {
+      serverLogger.error({ err }, 'airPurifierFan failed');
+      res.status(502).send('Air purifier fan control failed');
+    }
+  });
+
+  app.post('/airPurifierSpeed', cors(corsOptions), csrfMiddleware, async (req, res) => {
+    if (req.user?.role !== 'admin') {
+      res.status(403).send('Forbidden');
+      return;
+    }
+    const percentage = Number(req.body?.percentage);
+    if (!Number.isFinite(percentage)) {
+      res.status(400).send('percentage is required');
+      return;
+    }
+    try {
+      const result = await blueair.setSpeed(percentage);
+      res.send(result);
+    } catch (err) {
+      serverLogger.error({ err }, 'airPurifierSpeed failed');
+      res.status(502).send('Air purifier speed control failed');
+    }
+  });
+
+  app.post('/airPurifierPreset', cors(corsOptions), csrfMiddleware, async (req, res) => {
+    if (req.user?.role !== 'admin') {
+      res.status(403).send('Forbidden');
+      return;
+    }
+    const mode = String(req.body?.mode ?? '');
+    if (!mode) {
+      res.status(400).send('mode is required');
+      return;
+    }
+    try {
+      const result = await blueair.setPreset(mode);
+      res.send(result);
+    } catch (err) {
+      serverLogger.error({ err }, 'airPurifierPreset failed');
+      res.status(502).send('Air purifier preset control failed');
+    }
+  });
+
+  app.post('/airPurifierLight', cors(corsOptions), csrfMiddleware, async (req, res) => {
+    if (req.user?.role !== 'admin') {
+      res.status(403).send('Forbidden');
+      return;
+    }
+    try {
+      if (req.body?.brightness !== undefined) {
+        const brightness = Number(req.body.brightness);
+        if (!Number.isFinite(brightness)) {
+          res.status(400).send('brightness must be a number');
+          return;
+        }
+        const result = await blueair.setBrightness(brightness);
+        res.send(result);
+        return;
+      }
+      const result = await blueair.setLight(req.body?.on !== false);
+      res.send(result);
+    } catch (err) {
+      serverLogger.error({ err }, 'airPurifierLight failed');
+      res.status(502).send('Air purifier light control failed');
+    }
   });
 
   app.post('/startCar', cors(corsOptions), csrfMiddleware, async (req, res) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -698,7 +698,7 @@ export async function createServer(): Promise<Express> {
       return;
     }
     const mode = String(req.body?.mode ?? '');
-    if (!mode) {
+    if (!/^[a-zA-Z0-9_-]+$/.test(mode)) {
       res.status(400).send('mode is required');
       return;
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -747,8 +747,9 @@ export async function createServer(): Promise<Express> {
       res.status(403).send('Forbidden');
       return;
     }
-    if (req.body?.brightness !== undefined) {
-      const brightness = Number(req.body.brightness);
+    const rawBrightness = req.body?.brightness;
+    if (rawBrightness !== undefined && rawBrightness !== null && rawBrightness !== '') {
+      const brightness = Number(rawBrightness);
       if (!Number.isFinite(brightness)) {
         res.status(400).send('brightness must be a number');
         return;


### PR DESCRIPTION
## Summary
Adds control and monitoring for the Blue Pure air purifier via Home Assistant.

- New `Blueair` service (`src/blueair.ts`): polls the purifier (fan on/off, LED light, PM2.5, filter life, online status) and caches status. It does not write to InfluxDB — Home Assistant's native InfluxDB integration already logs these entities, so a duplicate write would be redundant.
- Exposes `airPurifier` cached status in the main `GET /` payload.
- Four CSRF-protected, admin-gated endpoints:
  - `POST /airPurifierFan` — turn fan on/off (requires an explicit `on` flag)
  - `POST /airPurifierSpeed` — set fan speed percentage
  - `POST /airPurifierPreset` — set preset mode (auto/night/manual; validated against the device's reported preset modes)
  - `POST /airPurifierLight` — toggle LED (`on` flag) or set `brightness`
- Entity IDs configurable via `BLUEAIR_*` env vars (defaults match the current Home Assistant entities).

## Notes
- Input validation returns `400` for missing/invalid `on`, `percentage`, `brightness`, or `mode`; upstream Home Assistant failures return `502`; an unsupported preset returns `400`.

## Testing
- `npm run lint` ✅
- `npm run build` ✅
- `npm test` ✅
