### PR TITLE
feat: add outdoor environment + energy metrics to catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,32 @@ INFLUXDB_BUCKET=fluxhaus
 
 If not configured, InfluxDB integration is silently disabled. Connect to an existing InfluxDB instance — no need to run one in docker-compose.
 
+## Metrics dashboard
+
+The app renders a Grafana-style dashboard from a server-defined catalog. Clients
+only reference metric ids — raw Flux/PromQL never leaves the server. Definitions
+live in `src/metrics.ts` (`METRIC_CATALOG`) and are exposed via:
+
+- `GET /metrics/catalog` — list of `{ id, title, unit, group }`
+- `GET /metrics/series?metric=<id>&range=<1h|6h|24h|7d|30d>` — time-series data
+
+Catalog groups:
+
+- **Environment** — indoor + outdoor temperature/humidity (Environment Canada),
+  indoor air quality (Blue Pure PM2.5), and outdoor air quality (AQHI). Outdoor
+  readings are relabelled **"Outside"** via each metric's `seriesRename` map so the
+  app can colour them consistently across charts.
+- **Energy** — live power draw (W) and cumulative energy (kWh) for the computer
+  station, media centre, and server hardware.
+- **Outdoor** — the full weather-tab detail set: outdoor temperature/humidity,
+  dew point, humidex, UV index, AQHI, and U.S./Chinese AQI (IQAir).
+- **Car**, **System**, **Network**, **Power** (UPS), **UniFi** — host and vehicle
+  telemetry from InfluxDB/Prometheus.
+
+Outdoor/environment series read Home Assistant data already flowing into InfluxDB
+(measurements keyed by unit, e.g. `climate`, `°C`, `μg/m³`, `UV index`, and
+`state` for index-style sensors) — no extra collector or env vars required.
+
 ## Calendar setup
 
 Calendars are available in both the MCP server and the AI command endpoint. The server keeps the existing Home Assistant calendar access and adds optional providers for iCloud, Microsoft 365, and subscribed ICS feeds.

--- a/src/__tests__/metrics.test.ts
+++ b/src/__tests__/metrics.test.ts
@@ -38,6 +38,32 @@ describe('metrics router', () => {
     expect(res.body.error).toMatch(/Unknown metric/);
   });
 
+  it('applies seriesRename to relabel the outdoor series as "Outside"', async () => {
+    const influxdb = {
+      configured: true,
+      query: jest.fn().mockResolvedValue([
+        {
+          _time: '2024-01-01T00:00:00Z', _value: '18.2', friendly_name: 'Environment Canada Temperature',
+        },
+      ]),
+    };
+    const app = buildApp({ influxdb: influxdb as never, bucket: 'fluxhaus' });
+    const res = await request(app).get('/metrics/series?metric=temperature').expect(200);
+    expect(res.body.series).toEqual([
+      { name: 'Outside', points: [{ t: '2024-01-01T00:00:00Z', v: 18.2 }] },
+    ]);
+  });
+
+  it('exposes Energy and Outdoor metric groups in the catalog', async () => {
+    const app = buildApp({});
+    const res = await request(app).get('/metrics/catalog').expect(200);
+    const groups = new Set(res.body.metrics.map((m: { group: string }) => m.group));
+    expect(groups.has('Energy')).toBe(true);
+    expect(groups.has('Outdoor')).toBe(true);
+    const ids = res.body.metrics.map((m: { id: string }) => m.id);
+    expect(ids).toEqual(expect.arrayContaining(['power_draw', 'aqhi', 'outdoor_air_quality']));
+  });
+
   it('returns 200 with series for a valid influx metric', async () => {
     const influxdb = {
       configured: true,

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -34,6 +34,10 @@ interface InfluxMetric {
   seriesTag: string;
   entityIds?: string[];
   aggregateFn?: 'mean' | 'last' | 'max' | 'min' | 'sum';
+  // Optional display-name overrides keyed by the resolved series name
+  // (e.g. rename the Environment Canada outdoor reading to "Outside" so the
+  // app can colour it consistently across every chart).
+  seriesRename?: Record<string, string>;
 }
 
 interface PrometheusMetric {
@@ -83,7 +87,9 @@ export const METRIC_CATALOG: MetricDefinition[] = [
       'kitchen_temperature',
       'living_room_temperature',
       'home_current_temperature',
+      'patio_environment_canada_temperature',
     ],
+    seriesRename: { 'Environment Canada Temperature': 'Outside' },
   },
   {
     id: 'humidity',
@@ -94,7 +100,8 @@ export const METRIC_CATALOG: MetricDefinition[] = [
     measurement: 'climate',
     field: 'value',
     seriesTag: 'friendly_name',
-    entityIds: ['home_current_humidity'],
+    entityIds: ['home_current_humidity', 'patio_environment_canada_humidity'],
+    seriesRename: { 'Environment Canada Humidity': 'Outside' },
   },
   {
     id: 'air_quality',
@@ -106,6 +113,18 @@ export const METRIC_CATALOG: MetricDefinition[] = [
     field: 'value',
     seriesTag: 'friendly_name',
     entityIds: ['blue_pure_pm_2_5'],
+  },
+  {
+    id: 'outdoor_air_quality',
+    title: 'Outdoor Air Quality (AQHI)',
+    unit: 'AQHI',
+    group: 'Environment',
+    source: 'influx',
+    measurement: 'state',
+    field: 'value',
+    seriesTag: 'friendly_name',
+    entityIds: ['patio_environment_canada_aqhi'],
+    seriesRename: { 'Environment Canada AQHI': 'Outside' },
   },
   {
     id: 'car_battery',
@@ -137,6 +156,133 @@ export const METRIC_CATALOG: MetricDefinition[] = [
     field: 'odometer',
     seriesTag: 'vehicle',
     aggregateFn: 'last',
+  },
+  {
+    id: 'power_draw',
+    title: 'Power Draw',
+    unit: 'W',
+    group: 'Energy',
+    source: 'influx',
+    measurement: 'power',
+    field: 'value',
+    seriesTag: 'friendly_name',
+    entityIds: [
+      'computer_station_power',
+      'media_centre_power',
+      'server_hardware_power',
+    ],
+  },
+  {
+    id: 'energy_total',
+    title: 'Energy (Total)',
+    unit: 'kWh',
+    group: 'Energy',
+    source: 'influx',
+    measurement: 'energy',
+    field: 'value',
+    seriesTag: 'friendly_name',
+    aggregateFn: 'last',
+    entityIds: [
+      'computer_station_energy',
+      'media_centre_energy',
+      'server_hardware_energy',
+    ],
+  },
+  {
+    id: 'outdoor_temperature',
+    title: 'Outdoor Temperature',
+    unit: '°C',
+    group: 'Outdoor',
+    source: 'influx',
+    measurement: 'climate',
+    field: 'value',
+    seriesTag: 'friendly_name',
+    entityIds: ['patio_environment_canada_temperature'],
+    seriesRename: { 'Environment Canada Temperature': 'Outside' },
+  },
+  {
+    id: 'outdoor_humidity',
+    title: 'Outdoor Humidity',
+    unit: '%',
+    group: 'Outdoor',
+    source: 'influx',
+    measurement: 'climate',
+    field: 'value',
+    seriesTag: 'friendly_name',
+    entityIds: ['patio_environment_canada_humidity'],
+    seriesRename: { 'Environment Canada Humidity': 'Outside' },
+  },
+  {
+    id: 'outdoor_dew_point',
+    title: 'Dew Point',
+    unit: '°C',
+    group: 'Outdoor',
+    source: 'influx',
+    measurement: '°C',
+    field: 'value',
+    seriesTag: 'friendly_name',
+    entityIds: ['patio_environment_canada_dew_point'],
+    seriesRename: { 'Environment Canada Dew point': 'Outside' },
+  },
+  {
+    id: 'outdoor_humidex',
+    title: 'Humidex',
+    unit: '°C',
+    group: 'Outdoor',
+    source: 'influx',
+    measurement: '°C',
+    field: 'value',
+    seriesTag: 'friendly_name',
+    entityIds: ['patio_environment_canada_humidex'],
+    seriesRename: { 'Environment Canada Humidex': 'Outside' },
+  },
+  {
+    id: 'uv_index',
+    title: 'UV Index',
+    unit: 'UV',
+    group: 'Outdoor',
+    source: 'influx',
+    measurement: 'UV index',
+    field: 'value',
+    seriesTag: 'friendly_name',
+    entityIds: ['patio_environment_canada_uv_index'],
+    seriesRename: { 'Environment Canada UV index': 'Outside' },
+  },
+  {
+    id: 'aqhi',
+    title: 'Air Quality Health Index',
+    unit: 'AQHI',
+    group: 'Outdoor',
+    source: 'influx',
+    measurement: 'state',
+    field: 'value',
+    seriesTag: 'friendly_name',
+    entityIds: ['patio_environment_canada_aqhi'],
+    seriesRename: { 'Environment Canada AQHI': 'Outside' },
+  },
+  {
+    id: 'us_aqi',
+    title: 'U.S. Air Quality Index',
+    unit: 'AQI',
+    group: 'Outdoor',
+    source: 'influx',
+    measurement: 'state',
+    field: 'value',
+    seriesTag: 'friendly_name',
+    entityIds: ['u_s_air_quality_index'],
+    seriesRename: { 'U.S. Air quality index': 'Outside' },
+  },
+  {
+    id: 'cn_aqi',
+    title: 'Chinese Air Quality Index',
+    unit: 'AQI',
+    group: 'Outdoor',
+    source: 'influx',
+    measurement: 'state',
+    field: 'value',
+    seriesTag: 'friendly_name',
+    entityIds: ['chinese_air_quality_index'],
+    seriesRename: { 'Chinese Air quality index': 'Outside' },
   },
   {
     id: 'cpu_usage',
@@ -315,7 +461,8 @@ async function fetchInflux(
     const value = parseFloat(row._value);
     /* eslint-enable no-underscore-dangle */
     if (!time || !Number.isFinite(value)) return;
-    const name = row[metric.seriesTag] || metric.title;
+    const rawName = row[metric.seriesTag] || metric.title;
+    const name = metric.seriesRename?.[rawName] ?? rawName;
     if (!grouped.has(name)) grouped.set(name, []);
     grouped.get(name)!.push({ t: time, v: value });
   });


### PR DESCRIPTION
## Summary

Extends the metrics dashboard catalog (`src/metrics.ts`) with outdoor environment data and household energy usage. The app consumes these automatically via `GET /metrics/catalog` — clients only reference metric ids.

### Environment (main dashboard)
- **Temperature** and **Humidity** charts now include the outdoor Environment Canada reading alongside the indoor rooms.
- New **Outdoor Air Quality (AQHI)** metric (official Environment Canada health index).
- Outdoor readings are relabelled **"Outside"** via a new per-metric `seriesRename` map so the app can colour them consistently across every chart.

### Energy (new group)
- **Power Draw** (W) and **Energy (Total)** (kWh) for the computer station, media centre, and server hardware.

### Outdoor (new group — powers the app's weather-tab detail screen)
- Outdoor temperature/humidity, dew point, humidex, UV index, AQHI, and U.S./Chinese AQI (IQAir).

All series read Home Assistant data already flowing into InfluxDB (measurements keyed by unit: `climate`, `°C`, `μg/m³`, `UV index`, and `state` for index-style sensors). **No new collector or env vars required.**

### Tests
- Added coverage for `seriesRename` (outdoor → "Outside") and for the new Energy/Outdoor catalog groups.
- `npm test`, `npm run lint`, and `npm run build` all pass locally. Queries validated against the live InfluxDB.

> ⚠️ Deploy note: left for @djensenius to merge/ship separately, since merging to `main` publishes a new Docker image.