### PR TITLE
Add server-side AQHI collector for dense air-quality data

### DIFF
--- a/src/__tests__/air-quality.test.ts
+++ b/src/__tests__/air-quality.test.ts
@@ -98,4 +98,20 @@ describe('AirQuality collector', () => {
     expect(value as number).toBeGreaterThanOrEqual(1);
     expect(value as number).toBeLessThan(11);
   });
+
+  it('normalizes a bare ECCC entity id and ignores NaN coordinates', async () => {
+    aq = new AirQuality({
+      client: mockClient,
+      fetchFn: mockFetch,
+      ecccEntityId: 'patio_environment_canada_aqhi',
+      latitude: NaN,
+      longitude: NaN,
+      pollInterval: 60_000,
+    });
+    await aq.collect();
+    expect(mockClient.getState).toHaveBeenCalledWith('sensor.patio_environment_canada_aqhi');
+    const url = String((mockFetch as jest.Mock).mock.calls[0][0]);
+    expect(url).toContain('latitude=43.4468');
+    expect(url).toContain('longitude=-80.4906');
+  });
 });

--- a/src/__tests__/air-quality.test.ts
+++ b/src/__tests__/air-quality.test.ts
@@ -1,0 +1,101 @@
+import AirQuality, {
+  computeAqhi,
+  no2Ugm3ToPpb,
+  ozoneUgm3ToPpb,
+} from '../air-quality';
+import { HomeAssistantClient } from '../homeassistant-client';
+import { writePoint } from '../influx';
+
+jest.mock('../homeassistant-client');
+jest.mock('../influx', () => ({
+  writePoint: jest.fn(),
+}));
+
+jest.mock('../logger', () => ({
+  __esModule: true,
+  default: {
+    child: () => ({
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    }),
+  },
+}));
+
+describe('computeAqhi', () => {
+  it('applies the Environment Canada formula and rounds', () => {
+    // O3 30 ppb, NO2 10 ppb, PM2.5 10 µg/m³ -> ~2.87 -> 3
+    expect(computeAqhi(30, 10, 10)).toBe(3);
+  });
+
+  it('floors the index at 1 for near-zero concentrations', () => {
+    expect(computeAqhi(0, 0, 0)).toBe(1);
+  });
+
+  it('increases with higher pollutant concentrations', () => {
+    expect(computeAqhi(120, 60, 80)).toBeGreaterThan(computeAqhi(30, 10, 10));
+  });
+});
+
+describe('unit conversions', () => {
+  it('converts ozone µg/m³ to ppb', () => {
+    expect(ozoneUgm3ToPpb(48)).toBeCloseTo(24.45, 2);
+  });
+
+  it('converts NO₂ µg/m³ to ppb', () => {
+    expect(no2Ugm3ToPpb(46.01)).toBeCloseTo(24.45, 2);
+  });
+});
+
+describe('AirQuality collector', () => {
+  let mockClient: jest.Mocked<HomeAssistantClient>;
+  let aq: AirQuality;
+
+  const hourly = (hours: number) => {
+    const time: string[] = [];
+    const now = Date.now();
+    for (let i = hours - 1; i >= 0; i -= 1) {
+      const d = new Date(now - i * 3600 * 1000);
+      time.push(`${d.toISOString().slice(0, 13)}:00`);
+    }
+    return {
+      time,
+      pm2_5: time.map(() => 10),
+      nitrogen_dioxide: time.map(() => 20),
+      ozone: time.map(() => 60),
+    };
+  };
+
+  const mockFetch = jest.fn(async () => ({
+    ok: true,
+    json: async () => ({ hourly: hourly(6) }),
+  })) as unknown as typeof fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockClient = new HomeAssistantClient({ url: 'http://test', token: 'token' }) as jest.Mocked<HomeAssistantClient>;
+    mockClient.getState = jest.fn().mockResolvedValue({ state: '4' });
+  });
+
+  afterEach(() => {
+    if (aq) aq.stop();
+  });
+
+  it('writes both AQHI series on collect', async () => {
+    aq = new AirQuality({ client: mockClient, fetchFn: mockFetch, pollInterval: 60_000 });
+    await aq.collect();
+
+    const entities = (writePoint as jest.Mock).mock.calls.map((c) => c[2].entity_id);
+    expect(entities).toContain('aqhi_open_meteo');
+    expect(entities).toContain('patio_environment_canada_aqhi');
+  });
+
+  it('computes a plausible AQHI from Open-Meteo data', async () => {
+    aq = new AirQuality({ client: mockClient, fetchFn: mockFetch, pollInterval: 60_000 });
+    const value = await aq.fetchOpenMeteoAqhi();
+    expect(value).not.toBeNull();
+    expect(value as number).toBeGreaterThanOrEqual(1);
+    expect(value as number).toBeLessThan(11);
+  });
+});

--- a/src/air-quality.ts
+++ b/src/air-quality.ts
@@ -19,6 +19,10 @@ const DEFAULT_LONGITUDE = -80.4906;
 
 const OPEN_METEO_URL = 'https://air-quality-api.open-meteo.com/v1/air-quality';
 
+// Abort the Open-Meteo request if it hangs, so overlapping 10-minute collects
+// can't accumulate in-flight fetches.
+const OPEN_METEO_TIMEOUT_MS = 10_000;
+
 // Molar-volume conversion (µg/m³ -> ppb) at 25 °C, 1013 hPa: ppb = µg/m³ × 24.45 / MW.
 const MOLAR_VOLUME = 24.45;
 const MW_O3 = 48.0;
@@ -30,6 +34,14 @@ export function ozoneUgm3ToPpb(ugm3: number): number {
 
 export function no2Ugm3ToPpb(ugm3: number): number {
   return (ugm3 * MOLAR_VOLUME) / MW_NO2;
+}
+
+// Ensure the configured ECCC sensor id includes a Home Assistant domain;
+// `/api/states/<id>` requires a `<domain>.<object_id>` entity id.
+function normalizeEntityId(entityId?: string): string {
+  const trimmed = entityId?.trim();
+  if (!trimmed) return `sensor.${ECCC_INFLUX_ENTITY_ID}`;
+  return trimmed.includes('.') ? trimmed : `sensor.${trimmed}`;
 }
 
 /**
@@ -92,9 +104,9 @@ export default class AirQuality {
 
   constructor(config: AirQualityConfig) {
     this.client = config.client;
-    this.latitude = config.latitude ?? DEFAULT_LATITUDE;
-    this.longitude = config.longitude ?? DEFAULT_LONGITUDE;
-    this.ecccEntityId = config.ecccEntityId || `sensor.${ECCC_INFLUX_ENTITY_ID}`;
+    this.latitude = Number.isFinite(config.latitude) ? (config.latitude as number) : DEFAULT_LATITUDE;
+    this.longitude = Number.isFinite(config.longitude) ? (config.longitude as number) : DEFAULT_LONGITUDE;
+    this.ecccEntityId = normalizeEntityId(config.ecccEntityId);
     this.fetchFn = config.fetchFn ?? fetch;
     this.startPolling(config.pollInterval ?? 1000 * 60 * 10);
   }
@@ -160,7 +172,14 @@ export default class AirQuality {
       forecast_days: '1',
       timezone: 'GMT',
     });
-    const response = await this.fetchFn(`${OPEN_METEO_URL}?${params.toString()}`);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), OPEN_METEO_TIMEOUT_MS);
+    let response: Response;
+    try {
+      response = await this.fetchFn(`${OPEN_METEO_URL}?${params.toString()}`, { signal: controller.signal });
+    } finally {
+      clearTimeout(timeout);
+    }
     if (!response.ok) {
       aqLogger.warn({ status: response.status }, 'Open-Meteo air-quality request failed');
       return null;
@@ -169,14 +188,15 @@ export default class AirQuality {
     const { hourly } = body;
     if (!hourly?.time?.length) return null;
 
-    // Find the most recent hour at or before now.
+    // Find the most recent hour at or before now. Open-Meteo returns forecast
+    // hours too, so bail out rather than computing AQHI from future samples.
     const now = Date.now();
     let endIndex = -1;
     for (let i = 0; i < hourly.time.length; i += 1) {
       if (new Date(`${hourly.time[i]}Z`).getTime() <= now) endIndex = i;
       else break;
     }
-    if (endIndex < 0) endIndex = hourly.time.length - 1;
+    if (endIndex < 0) return null;
 
     const pm25 = trailingAverage(hourly.pm2_5, endIndex);
     const no2 = trailingAverage(hourly.nitrogen_dioxide, endIndex);

--- a/src/air-quality.ts
+++ b/src/air-quality.ts
@@ -1,0 +1,188 @@
+import { HomeAssistantClient } from './homeassistant-client';
+import { writePoint } from './influx';
+import logger from './logger';
+
+const aqLogger = logger.child({ subsystem: 'air-quality' });
+
+// InfluxDB entity ids / friendly names for the two AQHI series. Both are
+// written under measurement "state" / field "value" so the existing
+// `outdoor_air_quality` and `aqhi` metrics pick them up (see metrics.ts).
+export const ECCC_INFLUX_ENTITY_ID = 'patio_environment_canada_aqhi';
+export const ECCC_INFLUX_FRIENDLY_NAME = 'Environment Canada AQHI';
+export const OPEN_METEO_INFLUX_ENTITY_ID = 'aqhi_open_meteo';
+export const OPEN_METEO_INFLUX_FRIENDLY_NAME = 'Open-Meteo';
+
+// Default Kitchener, ON coordinates (matches the app's fallback location and
+// the AirVisual/Environment Canada sensors already configured in HA).
+const DEFAULT_LATITUDE = 43.4468;
+const DEFAULT_LONGITUDE = -80.4906;
+
+const OPEN_METEO_URL = 'https://air-quality-api.open-meteo.com/v1/air-quality';
+
+// Molar-volume conversion (µg/m³ -> ppb) at 25 °C, 1013 hPa: ppb = µg/m³ × 24.45 / MW.
+const MOLAR_VOLUME = 24.45;
+const MW_O3 = 48.0;
+const MW_NO2 = 46.01;
+
+export function ozoneUgm3ToPpb(ugm3: number): number {
+  return (ugm3 * MOLAR_VOLUME) / MW_O3;
+}
+
+export function no2Ugm3ToPpb(ugm3: number): number {
+  return (ugm3 * MOLAR_VOLUME) / MW_NO2;
+}
+
+/**
+ * Environment Canada's Air Quality Health Index formula. Ozone and NO₂ are the
+ * 3-hour average concentrations in ppb; PM2.5 is the 3-hour average in µg/m³.
+ * The result is rounded to the nearest integer with a floor of 1, matching how
+ * Environment Canada publishes the index.
+ */
+export function computeAqhi(o3Ppb: number, no2Ppb: number, pm25Ugm3: number): number {
+  const raw = (1000 / 10.4) * (
+    (Math.exp(0.000537 * o3Ppb) - 1)
+    + (Math.exp(0.000871 * no2Ppb) - 1)
+    + (Math.exp(0.000487 * pm25Ugm3) - 1)
+  );
+  return Math.max(1, Math.round(raw));
+}
+
+interface OpenMeteoHourly {
+  time: string[];
+  pm2_5: (number | null)[];
+  nitrogen_dioxide: (number | null)[];
+  ozone: (number | null)[];
+}
+
+/**
+ * Average up to the three most recent hourly samples (at or before "now") for a
+ * pollutant, skipping gaps. Returns null when no usable sample exists.
+ */
+function trailingAverage(values: (number | null)[], endIndex: number): number | null {
+  const samples: number[] = [];
+  for (let i = endIndex; i >= 0 && samples.length < 3; i -= 1) {
+    const value = values[i];
+    if (typeof value === 'number' && Number.isFinite(value)) samples.push(value);
+  }
+  if (samples.length === 0) return null;
+  return samples.reduce((sum, v) => sum + v, 0) / samples.length;
+}
+
+export interface AirQualityConfig {
+  client: HomeAssistantClient;
+  latitude?: number;
+  longitude?: number;
+  ecccEntityId?: string;
+  pollInterval?: number;
+  fetchFn?: typeof fetch;
+}
+
+export default class AirQuality {
+  private client: HomeAssistantClient;
+
+  private latitude: number;
+
+  private longitude: number;
+
+  private ecccEntityId: string;
+
+  private fetchFn: typeof fetch;
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(config: AirQualityConfig) {
+    this.client = config.client;
+    this.latitude = config.latitude ?? DEFAULT_LATITUDE;
+    this.longitude = config.longitude ?? DEFAULT_LONGITUDE;
+    this.ecccEntityId = config.ecccEntityId || `sensor.${ECCC_INFLUX_ENTITY_ID}`;
+    this.fetchFn = config.fetchFn ?? fetch;
+    this.startPolling(config.pollInterval ?? 1000 * 60 * 10);
+  }
+
+  private startPolling(interval: number) {
+    this.collect().catch(() => {});
+    this.timer = setInterval(() => {
+      this.collect().catch(() => {});
+    }, interval);
+    this.timer.unref?.();
+  }
+
+  public stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** Fetch, compute, and persist both AQHI series. Public for testing. */
+  public async collect(): Promise<void> {
+    await Promise.all([this.collectOpenMeteo(), this.collectEnvironmentCanada()]);
+  }
+
+  private async collectOpenMeteo(): Promise<void> {
+    try {
+      const aqhi = await this.fetchOpenMeteoAqhi();
+      if (aqhi === null) return;
+      writePoint(
+        'state',
+        { value: aqhi },
+        { entity_id: OPEN_METEO_INFLUX_ENTITY_ID, friendly_name: OPEN_METEO_INFLUX_FRIENDLY_NAME },
+      );
+      aqLogger.debug({ aqhi }, 'Wrote Open-Meteo AQHI');
+    } catch (err) {
+      aqLogger.error({ err }, 'Failed to collect Open-Meteo AQHI');
+    }
+  }
+
+  private async collectEnvironmentCanada(): Promise<void> {
+    try {
+      const state = await this.client.getState(this.ecccEntityId);
+      const value = parseFloat(state?.state);
+      if (!Number.isFinite(value)) return;
+      writePoint(
+        'state',
+        { value },
+        { entity_id: ECCC_INFLUX_ENTITY_ID, friendly_name: ECCC_INFLUX_FRIENDLY_NAME },
+      );
+      aqLogger.debug({ value }, 'Wrote Environment Canada AQHI');
+    } catch (err) {
+      aqLogger.error({ err }, 'Failed to collect Environment Canada AQHI');
+    }
+  }
+
+  /** Compute AQHI from the latest Open-Meteo pollutant data. Public for testing. */
+  public async fetchOpenMeteoAqhi(): Promise<number | null> {
+    const params = new URLSearchParams({
+      latitude: String(this.latitude),
+      longitude: String(this.longitude),
+      hourly: 'pm2_5,nitrogen_dioxide,ozone',
+      past_days: '1',
+      forecast_days: '1',
+      timezone: 'GMT',
+    });
+    const response = await this.fetchFn(`${OPEN_METEO_URL}?${params.toString()}`);
+    if (!response.ok) {
+      aqLogger.warn({ status: response.status }, 'Open-Meteo air-quality request failed');
+      return null;
+    }
+    const body = await response.json() as { hourly?: OpenMeteoHourly };
+    const { hourly } = body;
+    if (!hourly?.time?.length) return null;
+
+    // Find the most recent hour at or before now.
+    const now = Date.now();
+    let endIndex = -1;
+    for (let i = 0; i < hourly.time.length; i += 1) {
+      if (new Date(`${hourly.time[i]}Z`).getTime() <= now) endIndex = i;
+      else break;
+    }
+    if (endIndex < 0) endIndex = hourly.time.length - 1;
+
+    const pm25 = trailingAverage(hourly.pm2_5, endIndex);
+    const no2 = trailingAverage(hourly.nitrogen_dioxide, endIndex);
+    const o3 = trailingAverage(hourly.ozone, endIndex);
+    if (pm25 === null || no2 === null || o3 === null) return null;
+
+    return computeAqhi(ozoneUgm3ToPpb(o3), no2Ugm3ToPpb(no2), pm25);
+  }
+}

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -123,8 +123,8 @@ export const METRIC_CATALOG: MetricDefinition[] = [
     measurement: 'state',
     field: 'value',
     seriesTag: 'friendly_name',
-    entityIds: ['patio_environment_canada_aqhi'],
-    seriesRename: { 'Environment Canada AQHI': 'Outside' },
+    entityIds: ['patio_environment_canada_aqhi', 'aqhi_open_meteo'],
+    seriesRename: { 'Environment Canada AQHI': 'Environment Canada' },
   },
   {
     id: 'car_battery',
@@ -257,8 +257,8 @@ export const METRIC_CATALOG: MetricDefinition[] = [
     measurement: 'state',
     field: 'value',
     seriesTag: 'friendly_name',
-    entityIds: ['patio_environment_canada_aqhi'],
-    seriesRename: { 'Environment Canada AQHI': 'Outside' },
+    entityIds: ['patio_environment_canada_aqhi', 'aqhi_open_meteo'],
+    seriesRename: { 'Environment Canada AQHI': 'Environment Canada' },
   },
   {
     id: 'us_aqi',

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,6 +27,7 @@ import HomeAssistantMiele from './homeassistant-miele';
 import HomeAssistantDishwasher from './homeassistant-dishwasher';
 import { createMetricsRouter } from './metrics';
 import Blueair from './blueair';
+import AirQuality from './air-quality';
 import adminRouter from './routes/admin.routes';
 import pushRouter from './routes/push.routes';
 import liveActivityTestRouter from './routes/live-activity-test.routes';
@@ -1556,6 +1557,19 @@ export async function createServer(): Promise<Express> {
   });
 
   startMonitor(allServices.homeAssistantClient, 30_000);
+
+  // Air Quality Health Index collector: stores the official Environment Canada
+  // AQHI (polled from HA) and a computed AQHI (from free Open-Meteo pollutant
+  // data) into InfluxDB on a 10-minute cadence, so the app's AQHI chart has a
+  // dense series instead of the sparse points HA writes only on state change.
+  // eslint-disable-next-line no-new
+  new AirQuality({
+    client: homeAssistantClient,
+    latitude: process.env.AQHI_LATITUDE ? parseFloat(process.env.AQHI_LATITUDE) : undefined,
+    longitude: process.env.AQHI_LONGITUDE ? parseFloat(process.env.AQHI_LONGITUDE) : undefined,
+    ecccEntityId: process.env.AQHI_ECCC_ENTITY_ID?.trim() || undefined,
+  });
+
   setAlertCallback((rule, _entity, message) => {
     serverLogger.info({ ruleId: rule.id, message }, 'Alert triggered');
     // TODO: send push notification when simple alert push is implemented


### PR DESCRIPTION
## Summary
The app's **Outdoor Air Quality (AQHI)** chart was nearly empty. Root cause: Home Assistant's InfluxDB integration only writes on **state change** (plus a snapshot on restart), and the Environment Canada AQHI is a coarse integer that almost never changes — so InfluxDB had only a couple of points.

This adds a server-side collector that populates InfluxDB directly on a **10-minute cadence** with two AQHI series:

1. **Environment Canada** — the official AQHI polled from HA (`sensor.patio_environment_canada_aqhi`), densifying the existing series.
2. **Open-Meteo** — a **computed** AQHI from free, keyless [Open-Meteo air-quality data](https://open-meteo.com/) (O₃/NO₂/PM2.5), using Environment Canada's published formula with 3-hour trailing averages and µg/m³→ppb conversions.

## Changes
- `src/air-quality.ts` — new `AirQuality` collector + pure `computeAqhi`/conversion helpers.
- `src/server.ts` — start the collector after `initInflux()`. Coordinates default to Kitchener (43.4468, -80.4906); overridable via `AQHI_LATITUDE`/`AQHI_LONGITUDE`/`AQHI_ECCC_ENTITY_ID`.
- `src/metrics.ts` — `outdoor_air_quality` and `aqhi` now include both entity ids with distinct series names (`Environment Canada`, `Open-Meteo`) so the app draws two differently-coloured lines.
- `src/__tests__/air-quality.test.ts` — unit tests for the formula, conversions, and collector writes.

## Validation
- `npm run lint` ✅
- `npm test` ✅ (528 passed)
- `npm run build` ✅
- `npx tsc --noEmit` ✅

Merging to main auto-deploys via docker-publish.
