### PR TITLE
Add outdoor PM2.5 series from Open-Meteo to the PM2.5 chart

### DIFF
--- a/src/__tests__/air-quality.test.ts
+++ b/src/__tests__/air-quality.test.ts
@@ -89,14 +89,26 @@ describe('AirQuality collector', () => {
     const entities = (writePoint as jest.Mock).mock.calls.map((c) => c[2].entity_id);
     expect(entities).toContain('aqhi_open_meteo');
     expect(entities).toContain('patio_environment_canada_aqhi');
+    expect(entities).toContain('pm25_open_meteo');
   });
 
-  it('computes a plausible AQHI from Open-Meteo data', async () => {
+  it('writes outdoor PM2.5 under the greek-mu measurement HA uses', async () => {
     aq = new AirQuality({ client: mockClient, fetchFn: mockFetch, pollInterval: 60_000 });
-    const value = await aq.fetchOpenMeteoAqhi();
-    expect(value).not.toBeNull();
-    expect(value as number).toBeGreaterThanOrEqual(1);
-    expect(value as number).toBeLessThan(11);
+    await aq.collect();
+
+    const pm25Call = (writePoint as jest.Mock).mock.calls.find((c) => c[2].entity_id === 'pm25_open_meteo');
+    expect(pm25Call).toBeDefined();
+    expect(pm25Call[0]).toBe('\u03BCg/m\u00B3');
+    expect(pm25Call[1].value).toBe(10);
+  });
+
+  it('computes a plausible AQHI and PM2.5 from Open-Meteo data', async () => {
+    aq = new AirQuality({ client: mockClient, fetchFn: mockFetch, pollInterval: 60_000 });
+    const readings = await aq.fetchOpenMeteoReadings();
+    expect(readings).not.toBeNull();
+    expect(readings!.aqhi).toBeGreaterThanOrEqual(1);
+    expect(readings!.aqhi).toBeLessThan(11);
+    expect(readings!.pm25).toBe(10);
   });
 
   it('normalizes a bare ECCC entity id and ignores NaN coordinates', async () => {

--- a/src/air-quality.ts
+++ b/src/air-quality.ts
@@ -12,10 +12,11 @@ export const ECCC_INFLUX_FRIENDLY_NAME = 'Environment Canada AQHI';
 export const OPEN_METEO_INFLUX_ENTITY_ID = 'aqhi_open_meteo';
 export const OPEN_METEO_INFLUX_FRIENDLY_NAME = 'Open-Meteo';
 
-// Outdoor PM2.5 (µg/m³) from Open-Meteo, written so it appears alongside the
-// indoor Blue Pure sensor on the app's "Air Quality (PM2.5)" chart. The
-// measurement must byte-match the greek-mu unit HA writes (see metrics.ts);
-// build it from code points to avoid editor-encoding mistakes.
+// Outdoor PM2.5 from Open-Meteo, written so it appears alongside the indoor
+// Blue Pure sensor on the app's "Air Quality (PM2.5)" chart. The measurement
+// must byte-match the unit Home Assistant writes, which uses U+03BC (Greek
+// small letter mu) followed by "g/m" and U+00B3 (superscript three). It is
+// built from code points below to avoid editor-encoding mistakes.
 export const PM25_INFLUX_MEASUREMENT = '\u03BCg/m\u00B3';
 export const OPEN_METEO_PM25_ENTITY_ID = 'pm25_open_meteo';
 export const OPEN_METEO_PM25_FRIENDLY_NAME = 'Open-Meteo';

--- a/src/air-quality.ts
+++ b/src/air-quality.ts
@@ -12,6 +12,14 @@ export const ECCC_INFLUX_FRIENDLY_NAME = 'Environment Canada AQHI';
 export const OPEN_METEO_INFLUX_ENTITY_ID = 'aqhi_open_meteo';
 export const OPEN_METEO_INFLUX_FRIENDLY_NAME = 'Open-Meteo';
 
+// Outdoor PM2.5 (µg/m³) from Open-Meteo, written so it appears alongside the
+// indoor Blue Pure sensor on the app's "Air Quality (PM2.5)" chart. The
+// measurement must byte-match the greek-mu unit HA writes (see metrics.ts);
+// build it from code points to avoid editor-encoding mistakes.
+export const PM25_INFLUX_MEASUREMENT = '\u03BCg/m\u00B3';
+export const OPEN_METEO_PM25_ENTITY_ID = 'pm25_open_meteo';
+export const OPEN_METEO_PM25_FRIENDLY_NAME = 'Open-Meteo';
+
 // Default Kitchener, ON coordinates (matches the app's fallback location and
 // the AirVisual/Environment Canada sensors already configured in HA).
 const DEFAULT_LATITUDE = 43.4468;
@@ -64,6 +72,11 @@ interface OpenMeteoHourly {
   pm2_5: (number | null)[];
   nitrogen_dioxide: (number | null)[];
   ozone: (number | null)[];
+}
+
+interface OpenMeteoReadings {
+  aqhi: number;
+  pm25: number;
 }
 
 /**
@@ -133,16 +146,21 @@ export default class AirQuality {
 
   private async collectOpenMeteo(): Promise<void> {
     try {
-      const aqhi = await this.fetchOpenMeteoAqhi();
-      if (aqhi === null) return;
+      const readings = await this.fetchOpenMeteoReadings();
+      if (readings === null) return;
       writePoint(
         'state',
-        { value: aqhi },
+        { value: readings.aqhi },
         { entity_id: OPEN_METEO_INFLUX_ENTITY_ID, friendly_name: OPEN_METEO_INFLUX_FRIENDLY_NAME },
       );
-      aqLogger.debug({ aqhi }, 'Wrote Open-Meteo AQHI');
+      writePoint(
+        PM25_INFLUX_MEASUREMENT,
+        { value: readings.pm25 },
+        { entity_id: OPEN_METEO_PM25_ENTITY_ID, friendly_name: OPEN_METEO_PM25_FRIENDLY_NAME },
+      );
+      aqLogger.debug({ aqhi: readings.aqhi, pm25: readings.pm25 }, 'Wrote Open-Meteo readings');
     } catch (err) {
-      aqLogger.error({ err }, 'Failed to collect Open-Meteo AQHI');
+      aqLogger.error({ err }, 'Failed to collect Open-Meteo readings');
     }
   }
 
@@ -162,8 +180,11 @@ export default class AirQuality {
     }
   }
 
-  /** Compute AQHI from the latest Open-Meteo pollutant data. Public for testing. */
-  public async fetchOpenMeteoAqhi(): Promise<number | null> {
+  /**
+   * Fetch the latest Open-Meteo pollutant data and derive the computed AQHI
+   * plus the outdoor PM2.5 concentration (3-hour average). Public for testing.
+   */
+  public async fetchOpenMeteoReadings(): Promise<OpenMeteoReadings | null> {
     const params = new URLSearchParams({
       latitude: String(this.latitude),
       longitude: String(this.longitude),
@@ -203,6 +224,9 @@ export default class AirQuality {
     const o3 = trailingAverage(hourly.ozone, endIndex);
     if (pm25 === null || no2 === null || o3 === null) return null;
 
-    return computeAqhi(ozoneUgm3ToPpb(o3), no2Ugm3ToPpb(no2), pm25);
+    return {
+      aqhi: computeAqhi(ozoneUgm3ToPpb(o3), no2Ugm3ToPpb(no2), pm25),
+      pm25: Math.round(pm25 * 10) / 10,
+    };
   }
 }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -112,7 +112,8 @@ export const METRIC_CATALOG: MetricDefinition[] = [
     measurement: 'μg/m³',
     field: 'value',
     seriesTag: 'friendly_name',
-    entityIds: ['blue_pure_pm_2_5'],
+    entityIds: ['blue_pure_pm_2_5', 'pm25_open_meteo'],
+    seriesRename: { 'Blue Pure PM 2.5': 'Indoor', 'Open-Meteo': 'Outdoor' },
   },
   {
     id: 'outdoor_air_quality',


### PR DESCRIPTION
## Summary
The **Air Quality (PM2.5)** chart only showed the indoor Blue Pure purifier sensor. This adds an **outdoor** PM2.5 line so you can compare indoor vs outdoor.

The AQHI collector already fetches Open-Meteo pollutant data (including PM2.5) every 10 minutes — this reuses that same fetch to also persist the outdoor PM2.5 concentration (3-hour average), written under the same greek-mu `µg/m³` measurement Home Assistant uses so it lands on the existing chart.

## Changes
- `src/air-quality.ts` — `fetchOpenMeteoReadings()` returns `{ aqhi, pm25 }` from one fetch; the collector writes an outdoor PM2.5 point (`entity_id: pm25_open_meteo`).
- `src/metrics.ts` — `air_quality` metric now includes both entity ids and renames the series to **Indoor** (Blue Pure) and **Outdoor** (Open-Meteo) so the app draws two differently-coloured lines.
- `src/__tests__/air-quality.test.ts` — added tests for the PM2.5 write and the exact measurement encoding.

## Validation
- `npm run lint` ✅
- `npm test` ✅ (530 passed)
- `npm run build` ✅
- `npx tsc --noEmit` ✅

Merging to main auto-deploys via docker-publish.
